### PR TITLE
Make registry.emisar.dev the canonical output

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -12,7 +12,7 @@ is the rules.
 ```bash
 terraform fmt -check -recursive
 terraform init -backend=false && terraform validate
-tflint --init && tflint
+tflint
 ```
 
 All three green before commit; CI (the `infra` job in `.github/workflows/ci.yml`) runs the same

--- a/infra/README.md
+++ b/infra/README.md
@@ -67,8 +67,10 @@ create/get/list/delete — no bucket config, no IAM). It can't be create-only:
 republishing the mutable pointers (`catalog.json`, `suggest.json`) *replaces* the
 live object, and GCS requires `storage.objects.delete` for an overwrite even with
 versioning on — `objectCreator` would 403 the second publish. Every replaced
-generation stays fetchable. Outputs: `pack_registry_bucket` and
-`pack_registry_base_url`. Recover an accidentally-overwritten mutable object (the
+generation stays fetchable. The canonical customer-facing output is
+`pack_registry_base_url` (`https://registry.emisar.dev`); the direct GCS endpoint
+is exposed separately as `pack_registry_backing_url` for storage administration
+and cutover diagnostics. Recover an accidentally-overwritten mutable object (the
 latest `catalog.json` pointer) from a prior generation:
 
 ```bash

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -50,13 +50,13 @@ output "pack_registry_bucket" {
 }
 
 output "pack_registry_base_url" {
-  description = "Public HTTPS base URL for pack artifacts — install snippets and the portal catalog loader join paths onto this (e.g. <base>/v1/catalog.json)."
-  value       = "https://storage.googleapis.com/${google_storage_bucket.pack_registry.name}"
+  description = "Canonical public HTTPS base URL for pack artifacts — install snippets and the portal catalog loader join paths onto this (e.g. <base>/v1/catalog.json)."
+  value       = "https://registry.${var.domain}"
 }
 
-output "pack_registry_domain_url" {
-  description = "Vendor-neutral serving domain for the same artifacts (shared LB → backend bucket). Live once its cert is ACTIVE and DNS resolves — GoDaddy records pre-cutover (see pack_registry_godaddy_records), dns.tf after. Flip packctl's --base-url default + EMISAR_PACK_CATALOG_URL to this base only AFTER verifying it serves."
-  value       = "https://registry.${var.domain}"
+output "pack_registry_backing_url" {
+  description = "Direct GCS backing URL for storage administration and cutover diagnostics; customer-facing catalogs and installers use pack_registry_base_url."
+  value       = "https://storage.googleapis.com/${google_storage_bucket.pack_registry.name}"
 }
 
 output "pack_registry_godaddy_records" {

--- a/packs/PUBLISHING.md
+++ b/packs/PUBLISHING.md
@@ -43,7 +43,7 @@ packctl catalog build --packs ./packs --out ./dist
 # Enforce the "preserve every version/hash" guarantee: fetch the currently
 # published catalog first and pass it as --previous. The build FAILS if any
 # pack changed bytes for an already-published id+version — bump the version.
-curl -fsS https://storage.googleapis.com/emisar-pack-registry/v1/catalog.json -o ./current-catalog.json
+curl -fsS https://registry.emisar.dev/v1/catalog.json -o ./current-catalog.json
 packctl catalog build --packs ./packs --out ./dist --previous ./current-catalog.json
 ```
 
@@ -75,7 +75,7 @@ conventional.
 ```bash
 # The published content hash for a pack must equal its local validate hash.
 emisar pack validate ./packs/redis          # prints "hash: sha256:…"
-curl -fsS https://storage.googleapis.com/emisar-pack-registry/v1/catalog.json \
+curl -fsS https://registry.emisar.dev/v1/catalog.json \
   | jq -r '.packs[] | select(.id=="redis") | .content_hash'
 
 # Round-trip the published tarball back to the same hash.
@@ -108,7 +108,7 @@ retired_below: 0.2.4   # 0.2.3 and earlier are now retired
 #    the build refuses to LOWER or DROP an already-published retired_below) and
 #    publish. Old tarballs stay installable — retirement blocks dispatch, not
 #    installation.
-curl -fsS https://storage.googleapis.com/emisar-pack-registry/v1/catalog.json -o ./current-catalog.json
+curl -fsS https://registry.emisar.dev/v1/catalog.json -o ./current-catalog.json
 packctl catalog build --packs ./packs --out ./dist --previous ./current-catalog.json
 packctl catalog publish --dir ./dist --bucket emisar-pack-registry
 


### PR DESCRIPTION
## Summary
- expose `https://registry.emisar.dev` as Terraform's canonical pack-registry base URL
- keep the GCS endpoint explicitly named as the backing URL for storage administration
- use the custom domain in normal publishing and verification examples
- align the infra TFLint gate with CI

## Verification
- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate`
- `tflint`
- `bash .agent/scripts/audit-llm-setup.sh`
- `git diff --check`