### PR TITLE
Reserve only the steady-state portal fleet

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -52,12 +52,14 @@ the separate, creds-gated deploy step.
    `testing → enforce`, gated on clean reports.
 8. **Migrations run on boot under Ecto's advisory lock** (cloud-init), so concurrent
    instances are safe. Committed portal migrations stay frozen (portal AGENTS.md §8).
-9. **Portal rollouts preserve serving capacity.** Keep one reserved surge slot,
-   `max_surge_fixed = 1`, and `max_unavailable_fixed = 0`. Auto-healing uses
+9. **Portal rollouts preserve serving capacity.** Reserve exactly the steady-state
+   fleet with automatic consumption and let the one-VM rollout surge use on-demand
+   capacity; a stockout may delay deployment but must not remove a serving VM. Keep
+   `max_surge_fixed = 1` and `max_unavailable_fixed = 0`. Auto-healing uses
    DB-independent `/healthz`; the load balancer uses DB-aware `/readyz`. Never
-   collapse the probes or return to delete-before-create updates. Old and new
-   app versions overlap during a rollout, so schema changes must be compatible
-   with both until a later release contracts the old shape.
+   collapse the probes or return to delete-before-create updates. Old and new app
+   versions overlap during a rollout, so schema changes must be compatible with
+   both until a later release contracts the old shape.
 
 ## House style
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -32,7 +32,7 @@ DNS A/AAAA ──────┤  HTTPS LB (TLS via   ├─► backend (HTTP /r
 | Area | Resources | SOC 2 relevance |
 |---|---|---|
 | Network | dedicated VPC + subnet (flow logs), Cloud Router + NAT, private service access | segmentation; DB/compute private (the only public read is the pack bucket) |
-| Compute | regional MIG of Container-Optimized OS running the portal image; Shielded VM; DB-independent auto-heal; one reserved surge VM and zero-unavailable rolling updates; `instance_count` 2+ forms one BEAM cluster | availability; host integrity |
+| Compute | regional MIG of Container-Optimized OS running the portal image; Shielded VM; DB-independent auto-heal; reserved steady-state fleet and zero-unavailable rolling updates with on-demand surge; `instance_count` 2+ forms one BEAM cluster | availability; host integrity |
 | Database | Cloud SQL Postgres 18 (latest major) — private IP, PITR backups, SSL-required, deletion-protected; `db_availability_type = "REGIONAL"` runs a synchronous standby with automatic failover | availability, durability/DR, confidentiality |
 | TLS | Certificate Manager managed cert (DNS-auth; apex + www + mta-sts SANs), RESTRICTED SSL policy (TLS 1.2+) | encryption in transit |
 | Secrets | TFC workspace variables → Secret Manager versions; per-secret least-priv access; machine secrets generated in-config | secret management |

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -55,26 +55,34 @@ resource "google_compute_health_check" "readiness" {
   depends_on = [google_project_service.apis]
 }
 
-# ── Capacity reservation: base fleet plus one rollout surge ──────────────────
-# Rollouts and auto-healing fail when the zone happens to be out of capacity at
-# the moment a replacement instance is created. Reserve the base fleet plus the
-# single surge slot required by the zero-unavailable update policy. The extra
-# slot bills while idle, but without it a zonal stockout can turn the availability
-# guarantee into a stuck rollout.
+# ── Capacity reservation: steady-state fleet ─────────────────────────────────
+# Guarantee capacity for the serving fleet without paying continuously for a
+# rollout-only VM. The one-VM surge remains zero-unavailable but uses ordinary
+# on-demand capacity, so a zonal stockout can delay a rollout without reducing
+# the already-running serving capacity.
 resource "google_compute_reservation" "emisar" {
-  name = "emisar"
+  name = "emisar-base"
   zone = var.zone
 
-  # Only instances that explicitly target this reservation consume it — a
-  # stray VM in the project can't silently eat the fleet's slots.
-  specific_reservation_required = true
+  specific_reservation_required = false
 
+  # The provider calls the reserved machine shape "specific_reservation" even
+  # when consumption is automatic. Matching VMs may consume these slots.
   specific_reservation {
-    count = var.instance_count + 1
+    count = var.instance_count
     instance_properties {
       machine_type = var.machine_type
     }
   }
+
+  # Changing a specifically targeted reservation to automatic consumption
+  # requires replacement. Create the new base reservation before rolling the
+  # template, then release the old reservation after its VMs are gone.
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [google_project_service.apis]
 }
 
 # ── Instance template: Container-Optimized OS running the portal container ────
@@ -116,13 +124,10 @@ resource "google_compute_instance_template" "emisar" {
     enable_integrity_monitoring = true
   }
 
-  # Every fleet and surge instance consumes the dedicated reservation above.
+  # Base instances automatically consume the matching reservation above. Once
+  # those slots are full, a rollout surge can still use on-demand capacity.
   reservation_affinity {
-    type = "SPECIFIC_RESERVATION"
-    specific_reservation {
-      key    = "compute.googleapis.com/reservation-name"
-      values = [google_compute_reservation.emisar.name]
-    }
+    type = "ANY_RESERVATION"
   }
 
   metadata = {
@@ -143,7 +148,10 @@ resource "google_compute_instance_template" "emisar" {
     create_before_destroy = true
   }
 
-  depends_on = [google_project_service.apis]
+  depends_on = [
+    google_project_service.apis,
+    google_compute_reservation.emisar,
+  ]
 }
 
 # ── Regional Managed Instance Group: auto-healing + rolling updates ──────────
@@ -157,9 +165,9 @@ resource "google_compute_region_instance_group_manager" "emisar" {
   region                           = var.region
   target_size                      = var.instance_count
   distribution_policy_target_shape = "BALANCED"
-  # Pinned to the reservation's zone so every instance can consume it. Zone
-  # redundancy at 2+ instances = more zones with a per-zone reservation each —
-  # a deliberate change (see var.zone).
+  # Pinned to the base reservation's zone so every steady-state instance can
+  # consume it. Zone redundancy at 2+ instances = more zones with a per-zone
+  # reservation each — a deliberate change (see var.zone).
   distribution_policy_zones = [var.zone]
 
   # Block `terraform apply` until the rollout is healthy, so a broken deploy FAILS

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -11,7 +11,7 @@ variable "region" {
 
 variable "zone" {
   type        = string
-  description = "Zone the MIG places instances in and the capacity reservation lives in (must be inside var.region). Single-zone by design at the current size — the reservation covers the base fleet plus one zero-downtime rollout surge; at 2+ instances, zone redundancy means adding zones with a per-zone reservation each (a deliberate change, not a default)."
+  description = "Zone the MIG places instances in and the capacity reservation lives in (must be inside var.region). Single-zone by design at the current size — the reservation covers the steady-state fleet while rollout surge capacity is on-demand; at 2+ instances, zone redundancy means adding zones with a per-zone reservation each (a deliberate change, not a default)."
   default     = "us-central1-a"
 }
 


### PR DESCRIPTION
## Summary
- reserve exactly the steady-state MIG capacity
- automatically consume matching reserved capacity
- keep the one-VM zero-downtime surge on demand
- migrate safely with create-before-destroy

## Verification
- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate`
- `tflint`
- `.agent/scripts/audit-llm-setup.sh`