### PR TITLE
Restrict public pack registry access to object reads

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/betterstackhq/better-uptime" {
+  version     = "0.21.9"
+  constraints = "~> 0.21"
+  hashes = [
+    "h1:9QfEHiaKsLlRptrsrvBzErbwfKtBQqLlCZke92axHi4=",
+    "zh:031e1dc3b2078d152246e9209febe75c996cf0ce72b6dbe91e5676fa281f7e8a",
+    "zh:12fbc47f2854a45db3437b94b836360894d6b90eebecac022b35573328356809",
+    "zh:2cd1bca7176dad4dd983cb09fd0c514ee5453eecdef3df1c59acd8df6b7a30be",
+    "zh:3515f4680579cb9509ad933d752b3ec8e27b98936014fc58361eba665553eb3b",
+    "zh:4eaacbd19b07d81efac099a256a3fda50cc9b2b44a7248fc0385ba4162dc7fe5",
+    "zh:580874be87cfad8c604c24e9cc5bd7958e68d06f6e9baa578c078de009de370f",
+    "zh:5b1cf74cd83740771bbc4654b9e59ed31e7bac8089be5a86845cbc2e9f93f9ef",
+    "zh:6e9ce3c2ffb2212e9df0300c30649bf15b3694f071629e1671d457101d268529",
+    "zh:85b211c1896cb03c6d3b4c55375b37e84bbafe06ca48c5179df7da4c0b3c32e5",
+    "zh:9ae6fe1d7b593b13ab26406b61fbfdff2fed0fb615fbf7439a8b1ac2524696ec",
+    "zh:ddc34de57e82a5d9fdd6511eaec5c17a3d0840cf8b53bee0506a14b01191b74b",
+    "zh:e35467234cced48384815ac5d1d52df2405640035d6fba612107926b0d762034",
+    "zh:e58769dcefb1fb4d9e5391e2d4ee23635960390ced618896f5ff4b69d7303dd7",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "7.39.0"
   constraints = "~> 7.0"

--- a/infra/README.md
+++ b/infra/README.md
@@ -97,9 +97,9 @@ credential is `betterstack_api_token`, a **sensitive TFC workspace variable**
 `https://emisar.betteruptime.com` immediately; `status.emisar.dev` (CNAME in
 `dns.tf`, Let's Encrypt already in `var.caa_issuers`) activates at NS
 delegation — or earlier by adding the same CNAME at GoDaddy, which needs no CAA
-change (the runbook keeps `letsencrypt.org` for Fly). The pack-registry monitor
-ships **paused**: unpause it when `registry.emisar.dev` resolves publicly
-(runbook step 3d in `terraform output next_steps`), not before.
+change (the runbook keeps `letsencrypt.org` for Fly). Both monitors are live:
+`registry.emisar.dev` already resolves publicly (it went live independently,
+ahead of the traffic cutover).
 
 ## Clustering (emisar-specific vs onlytty)
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -40,7 +40,7 @@ DNS A/AAAA ──────┤  HTTPS LB (TLS via   ├─► backend (HTTP /r
 | Pack registry | GCS bucket, **public-read** (the one deliberate public surface), object-versioned, create-only publisher SA; serves catalog/suggest/schema + immutable pack tarballs | integrity; supply-chain transparency |
 | IAM | dedicated least-priv service account; Data Access audit logging | logical access; audit trail |
 | DNS | Cloud DNS zone (DNSSEC ECDSA) + full email posture (SPF/DKIM/DMARC/CAA/TLS-RPT/MTA-STS) | integrity; anti-spoofing |
-| Monitoring | uptime check + alert policies (unreachable, LB 5xx ratio, cert renewal failing, MIG below target, NAT exhaustion, DB CPU/memory/disk/txid-wraparound) → email channel; independent external probes + public status page via Better Stack (`uptime.tf`) | detection; customer communication |
+| Monitoring | uptime check + alert policies (unreachable, LB 5xx ratio, cert renewal failing, MIG below target, NAT exhaustion, DB CPU/memory/disk/txid-wraparound) → email channel; independent external probes, on-call rotation + escalation, and public status page via Better Stack (`uptime.tf`) | detection; incident response; customer communication |
 
 Normal image rollouts create a replacement, wait until it has reached readiness,
 and only then drain the old VM. Because old and new application versions overlap,
@@ -87,15 +87,22 @@ gcloud storage ls -a gs://$(terraform output -raw pack_registry_bucket)/v1/catal
 gcloud storage cp gs://<bucket>/v1/catalog.json#<generation> gs://<bucket>/v1/catalog.json # restore one
 ```
 
-## External uptime & status page (Better Stack)
+## External uptime, on-call & status page (Better Stack)
 
 `monitoring.tf` watches from inside Google; `uptime.tf` watches from outside it.
-Better Stack probes the **public hostname** from independent infrastructure and
-hosts the public status page — so detection and customer communication survive
-an incident in the serving cloud, and the monitors already watch the Fly
-deployment today (they follow traffic at cutover with no change). The provider
-credential is `betterstack_api_token`, a **sensitive TFC workspace variable**
-(same custody rule as every secret here). The status page serves at
+Better Stack probes the **public hostname** from independent infrastructure,
+runs the **on-call escalation** (notify → wake with a phone call → wake
+everyone, repeating), and hosts the public status page — so detection, paging,
+and customer communication survive an incident in the serving cloud. The
+monitors already watch the Fly deployment today (they follow traffic at
+cutover with no change). Two **sensitive TFC workspace variables** feed it:
+`betterstack_api_token` (the provider credential) and `oncall_emails` (the
+rotation roster — sensitive on purpose, so this public repo reveals neither
+who is on call nor how many people that is; team invites happen in the Better
+Stack UI, never as per-person Terraform resources). The account predates this
+config, so the pre-existing status page, apex monitor (with its uptime
+history), and default on-call calendar are adopted via `import` blocks — no-ops
+after the first apply. The status page serves at
 `https://emisar.betteruptime.com` immediately; `status.emisar.dev` (CNAME in
 `dns.tf`, Let's Encrypt already in `var.caa_issuers`) activates at NS
 delegation — or earlier by adding the same CNAME at GoDaddy, which needs no CAA

--- a/infra/README.md
+++ b/infra/README.md
@@ -67,7 +67,9 @@ the immutable pack tarballs — live in a **public-read** GCS bucket
 nothing secret or account-scoped is ever written there (only pack bytes that are
 already public source in `packs/` plus their metadata), and install trust doesn't
 rest on the transport — snippets pin `--hash sha256:...` and the runner rejects any
-tampered tarball. History is preserved by **object versioning** (no lifecycle
+tampered tarball. Anonymous access is limited to GET by exact object path; the
+bucket root is intentionally not a directory listing. History is preserved by
+**object versioning** (no lifecycle
 delete rule; the bucket is `prevent_destroy`), and the CI publisher SA
 (`emisar-pack-publisher`) holds bucket-scoped **`objectUser`** (objects
 create/get/list/delete — no bucket config, no IAM). It can't be create-only:

--- a/infra/README.md
+++ b/infra/README.md
@@ -40,7 +40,7 @@ DNS A/AAAA ──────┤  HTTPS LB (TLS via   ├─► backend (HTTP /r
 | Pack registry | GCS bucket, **public-read** (the one deliberate public surface), object-versioned, create-only publisher SA; serves catalog/suggest/schema + immutable pack tarballs | integrity; supply-chain transparency |
 | IAM | dedicated least-priv service account; Data Access audit logging | logical access; audit trail |
 | DNS | Cloud DNS zone (DNSSEC ECDSA) + full email posture (SPF/DKIM/DMARC/CAA/TLS-RPT/MTA-STS) | integrity; anti-spoofing |
-| Monitoring | uptime check + alert policies (unreachable, LB 5xx ratio, cert renewal failing, MIG below target, NAT exhaustion, DB CPU/memory/disk/txid-wraparound) → email channel | detection |
+| Monitoring | uptime check + alert policies (unreachable, LB 5xx ratio, cert renewal failing, MIG below target, NAT exhaustion, DB CPU/memory/disk/txid-wraparound) → email channel; independent external probes + public status page via Better Stack (`uptime.tf`) | detection; customer communication |
 
 Normal image rollouts create a replacement, wait until it has reached readiness,
 and only then drain the old VM. Because old and new application versions overlap,
@@ -52,7 +52,8 @@ zero-downtime deployment.
 
 `network.tf` · `compute.tf` · `db.tf` · `lb.tf` · `secrets.tf` · `iam.tf`
 (SA + audit) · `packs_registry.tf` (public pack bucket + publisher SA) ·
-`monitoring.tf` · `dns.tf` · `main.tf` (TFC backend + provider +
+`monitoring.tf` · `uptime.tf` (Better Stack external probes + status page) ·
+`dns.tf` · `main.tf` (TFC backend + provider +
 APIs) · `variables.tf` · `outputs.tf` · `versions.tf` ·
 `templates/cloud-init.yaml` · `scripts/verify-cutover.sh`.
 
@@ -83,6 +84,22 @@ latest `catalog.json` pointer) from a prior generation:
 gcloud storage ls -a gs://$(terraform output -raw pack_registry_bucket)/v1/catalog.json   # list generations
 gcloud storage cp gs://<bucket>/v1/catalog.json#<generation> gs://<bucket>/v1/catalog.json # restore one
 ```
+
+## External uptime & status page (Better Stack)
+
+`monitoring.tf` watches from inside Google; `uptime.tf` watches from outside it.
+Better Stack probes the **public hostname** from independent infrastructure and
+hosts the public status page — so detection and customer communication survive
+an incident in the serving cloud, and the monitors already watch the Fly
+deployment today (they follow traffic at cutover with no change). The provider
+credential is `betterstack_api_token`, a **sensitive TFC workspace variable**
+(same custody rule as every secret here). The status page serves at
+`https://emisar.betteruptime.com` immediately; `status.emisar.dev` (CNAME in
+`dns.tf`, Let's Encrypt already in `var.caa_issuers`) activates at NS
+delegation — or earlier by adding the same CNAME at GoDaddy, which needs no CAA
+change (the runbook keeps `letsencrypt.org` for Fly). The pack-registry monitor
+ships **paused**: unpause it when `registry.emisar.dev` resolves publicly
+(runbook step 3d in `terraform output next_steps`), not before.
 
 ## Clustering (emisar-specific vs onlytty)
 

--- a/infra/db.tf
+++ b/infra/db.tf
@@ -16,11 +16,13 @@ resource "google_sql_database_instance" "emisar" {
   # window, never an edit-and-forget.
   database_version = "POSTGRES_18"
 
-  # Guards `terraform destroy` / a destructive replacement at the API level, on top
-  # of the Terraform lifecycle guard below.
+  # Blocks Terraform-driven deletion; the API-level guard below separately blocks
+  # direct gcloud/API deletion outside Terraform.
   deletion_protection = true
 
   settings {
+    deletion_protection_enabled = true
+
     # Pinned: left unset, Postgres 18 instances default to ENTERPRISE_PLUS,
     # which only accepts db-perf-optimized-N-* tiers — the create then 400s on
     # any shared-core or db-custom tier. ENTERPRISE covers our whole tier dial;

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -68,6 +68,11 @@ output "pack_registry_godaddy_records" {
   }
 }
 
+output "status_page_url" {
+  description = "Public status page (Better Stack). The custom domain resolves once the zone is authoritative — or earlier by adding `status CNAME statuspage.betteruptime.com` at the current registrar; until then the page serves at https://<subdomain>.betteruptime.com."
+  value       = "https://status.${var.domain}"
+}
+
 output "next_steps" {
   description = "The remaining path to production, in order. Full commands: README «Cutover runbook»."
   value       = <<-EOT

--- a/infra/packs_registry.tf
+++ b/infra/packs_registry.tf
@@ -50,12 +50,23 @@ resource "google_storage_bucket" "pack_registry" {
   }
 }
 
-# Public read for artifact objects — the reason the bucket exists. `objectViewer`
-# grants GET on objects only (not bucket config, not writes, not listing the
-# bucket via allUsers), which is exactly what `emisar pack install` needs.
+# Public read for artifact objects — the reason the bucket exists. The built-in
+# `roles/storage.objectViewer` also grants `storage.objects.list`, which exposes
+# an anonymous bucket index. Use a project custom role with only GET so every
+# published object remains fetchable by its exact URL while the bucket root is
+# not a discovery surface.
+resource "google_project_iam_custom_role" "pack_registry_public_reader" {
+  project     = var.project_id
+  role_id     = "packRegistryPublicReader"
+  title       = "Pack Registry Public Object Reader"
+  description = "Anonymous GET access to published pack-registry objects without bucket listing."
+  permissions = ["storage.objects.get"]
+  stage       = "GA"
+}
+
 resource "google_storage_bucket_iam_member" "pack_registry_public_read" {
   bucket = google_storage_bucket.pack_registry.name
-  role   = "roles/storage.objectViewer"
+  role   = google_project_iam_custom_role.pack_registry_public_reader.name
   member = "allUsers"
 }
 
@@ -70,7 +81,7 @@ resource "google_storage_bucket_iam_member" "pack_registry_public_read" {
 # lifecycle delete rule. Accepted residual: this SA *could* explicitly delete
 # archived generations — install trust rests on the pinned `--hash` in the
 # snippets, not on the registry. Reads for post-publish verification go through
-# the public objectViewer binding above (IAM is additive).
+# the public GET-only binding above (IAM is additive).
 resource "google_service_account" "pack_publisher" {
   account_id   = "emisar-pack-publisher"
   display_name = "emisar pack registry publisher"

--- a/infra/uptime.tf
+++ b/infra/uptime.tf
@@ -36,17 +36,13 @@ resource "betteruptime_monitor" "portal" {
   sms   = false
 }
 
-# The unauthenticated `emisar pack install` path. Paused until
-# registry.<domain> resolves publicly (README cutover runbook — the registry
-# can go live independently, before any traffic move); unpause it then, or the
-# monitor pages about DNS that is intentionally not delegated yet.
+# The unauthenticated `emisar pack install` path — live ahead of the main
+# cutover (the registry went public independently, per the runbook).
 resource "betteruptime_monitor" "pack_registry" {
   url          = "https://registry.${var.domain}/v1/catalog.json"
   monitor_type = "status"
 
   pronounceable_name = "emisar pack registry"
-
-  paused = true
 
   follow_redirects = false
   remember_cookies = false

--- a/infra/uptime.tf
+++ b/infra/uptime.tf
@@ -1,0 +1,111 @@
+# ── External uptime + status page (Better Stack) — SOC 2 CC7 ─────────────────
+# Google's uptime check (monitoring.tf) shares a failure domain with everything
+# it watches: an incident in the serving cloud can take out the site AND the
+# alert path in one stroke. Better Stack probes from independent infrastructure
+# and hosts the public status page, so detection and customer communication
+# both survive the outage they report on. It also monitors the PUBLIC hostname,
+# which means it watches the Fly deployment today and follows traffic to GCP at
+# cutover with no change here.
+
+provider "betteruptime" {
+  api_token = var.betterstack_api_token
+}
+
+# /readyz is DB-aware, so "up" attests the web tier AND its database — the same
+# contract the LB uses (compute.tf), verified from outside.
+resource "betteruptime_monitor" "portal" {
+  url          = "https://${var.domain}/readyz"
+  monitor_type = "status"
+
+  pronounceable_name = "emisar portal"
+
+  follow_redirects = false
+  remember_cookies = false
+  verify_ssl       = true
+
+  # The GCP-side cert-renewal alert (monitoring.tf) only observes traffic after
+  # cutover; these watch expiry on whatever is actually serving the domain.
+  ssl_expiration    = 7
+  domain_expiration = 14
+
+  # Solo-operator alerting: email + mobile push, no call/SMS chain. When there
+  # is an on-call rotation, replace these with a betteruptime_policy escalation.
+  email = true
+  push  = true
+  call  = false
+  sms   = false
+}
+
+# The unauthenticated `emisar pack install` path. Paused until
+# registry.<domain> resolves publicly (README cutover runbook — the registry
+# can go live independently, before any traffic move); unpause it then, or the
+# monitor pages about DNS that is intentionally not delegated yet.
+resource "betteruptime_monitor" "pack_registry" {
+  url          = "https://registry.${var.domain}/v1/catalog.json"
+  monitor_type = "status"
+
+  pronounceable_name = "emisar pack registry"
+
+  paused = true
+
+  follow_redirects = false
+  remember_cookies = false
+  verify_ssl       = true
+
+  ssl_expiration    = 7
+  domain_expiration = 14
+
+  email = true
+  push  = true
+  call  = false
+  sms   = false
+}
+
+# ── Public status page ────────────────────────────────────────────────────────
+# status.<domain> CNAMEs to Better Stack in dns.tf, and var.caa_issuers already
+# allows Let's Encrypt for it. The custom domain activates once the zone is
+# authoritative (or earlier via the same CNAME at the current registrar); until
+# then the page serves at https://<subdomain>.betteruptime.com.
+resource "betteruptime_status_page" "emisar" {
+  company_name = "emisar"
+  company_url  = "https://${var.domain}"
+
+  timezone = "UTC"
+
+  subdomain     = "emisar"
+  custom_domain = "status.${var.domain}"
+
+  design = "v2"
+  theme  = "light"
+  layout = "vertical"
+}
+
+resource "betteruptime_status_page_section" "control_plane" {
+  status_page_id = betteruptime_status_page.emisar.id
+  name           = "Control plane"
+}
+
+resource "betteruptime_status_page_resource" "portal" {
+  status_page_id         = betteruptime_status_page.emisar.id
+  status_page_section_id = betteruptime_status_page_section.control_plane.id
+
+  public_name = "Portal, console & MCP API"
+
+  resource_type = "Monitor"
+  resource_id   = betteruptime_monitor.portal.id
+}
+
+resource "betteruptime_status_page_section" "distribution" {
+  status_page_id = betteruptime_status_page.emisar.id
+  name           = "Distribution"
+}
+
+resource "betteruptime_status_page_resource" "pack_registry" {
+  status_page_id         = betteruptime_status_page.emisar.id
+  status_page_section_id = betteruptime_status_page_section.distribution.id
+
+  public_name = "Pack registry"
+
+  resource_type = "Monitor"
+  resource_id   = betteruptime_monitor.pack_registry.id
+}

--- a/infra/uptime.tf
+++ b/infra/uptime.tf
@@ -1,23 +1,141 @@
-# ── External uptime + status page (Better Stack) — SOC 2 CC7 ─────────────────
+# ── External uptime, on-call & status page (Better Stack) — SOC 2 CC7 ────────
 # Google's uptime check (monitoring.tf) shares a failure domain with everything
 # it watches: an incident in the serving cloud can take out the site AND the
-# alert path in one stroke. Better Stack probes from independent infrastructure
-# and hosts the public status page, so detection and customer communication
-# both survive the outage they report on. It also monitors the PUBLIC hostname,
-# which means it watches the Fly deployment today and follows traffic to GCP at
-# cutover with no change here.
+# alert path in one stroke. Better Stack probes from independent infrastructure,
+# runs the on-call escalation, and hosts the public status page — so detection,
+# paging, and customer communication all survive the outage they report on. It
+# also monitors the PUBLIC hostname, which means it watches the Fly deployment
+# today and follows traffic to GCP at cutover with no change here.
+#
+# The account predates this config, so the pre-existing resources are adopted
+# via import blocks (no-ops after the first apply) instead of being recreated —
+# recreating them would discard the status page's uptime history.
 
 provider "betteruptime" {
   api_token = var.betterstack_api_token
 }
 
+import {
+  to = betteruptime_on_call_calendar.primary
+  id = "391634"
+}
+
+import {
+  to = betteruptime_monitor.portal
+  id = "4499550"
+}
+
+import {
+  to = betteruptime_status_page.emisar
+  id = "250271"
+}
+
+import {
+  to = betteruptime_status_page_section.control_plane
+  id = "250271/330559"
+}
+
+import {
+  to = betteruptime_status_page_resource.portal
+  id = "250271/8901315"
+}
+
+# ── On-call & escalation ──────────────────────────────────────────────────────
+# The roster lives in var.oncall_emails (a SENSITIVE workspace variable), so the
+# public repo reveals neither who is on call nor how many people that is — the
+# same reason there is no betteruptime_team_member resource here: one resource
+# instance per person would put the headcount in the plan. People are invited
+# to Better Stack out of band; the rotation references them by account email.
+resource "betteruptime_on_call_calendar" "primary" {
+  name = "Primary on-call schedule"
+
+  on_call_rotation {
+    users             = var.oncall_emails
+    rotation_interval = "week"
+    rotation_length   = 1
+
+    # Fixed anchors on purpose: timestamp() would re-anchor the rotation every
+    # apply. Monday-start weeks; the far end is "until we change this config".
+    start_rotations_at = "2026-07-13T00:00:00Z"
+    end_rotations_at   = "2036-07-13T00:00:00Z"
+  }
+}
+
+# Two urgencies: a polite nudge, then one that cuts through Do-Not-Disturb.
+resource "betteruptime_severity" "notify" {
+  name = "Notify on-call"
+
+  email = true
+  push  = true
+
+  critical_alert = false
+  call           = false
+  sms            = false
+}
+
+resource "betteruptime_severity" "wake" {
+  name = "Wake on-call"
+
+  critical_alert = true
+  call           = true
+  sms            = true
+
+  email = false
+  push  = false
+}
+
+# Escalation: notify the on-call immediately; if unacknowledged, call them at
+# 3 minutes; at 10 minutes call EVERYONE. Repeats 3× so a missed first wave
+# does not end the paging.
+resource "betteruptime_policy" "incident" {
+  name = "emisar service down"
+
+  steps {
+    type        = "escalation"
+    wait_before = 0
+    urgency_id  = betteruptime_severity.notify.id
+
+    step_members {
+      type = "current_on_call"
+    }
+  }
+
+  steps {
+    type        = "escalation"
+    wait_before = 3 * 60
+    urgency_id  = betteruptime_severity.wake.id
+
+    step_members {
+      type = "current_on_call"
+    }
+  }
+
+  steps {
+    type        = "escalation"
+    wait_before = 7 * 60
+    urgency_id  = betteruptime_severity.wake.id
+
+    step_members {
+      type = "entire_team"
+    }
+  }
+
+  repeat_count = 3
+  repeat_delay = 5 * 60
+}
+
+# ── Monitors ──────────────────────────────────────────────────────────────────
 # /readyz is DB-aware, so "up" attests the web tier AND its database — the same
-# contract the LB uses (compute.tf), verified from outside.
+# contract the LB uses (compute.tf), verified from outside. Imported from the
+# manually-created apex monitor to keep its uptime history; the config moves it
+# from / to /readyz and attaches the escalation policy.
 resource "betteruptime_monitor" "portal" {
   url          = "https://${var.domain}/readyz"
   monitor_type = "status"
 
   pronounceable_name = "emisar portal"
+
+  policy_id = betteruptime_policy.incident.id
 
   follow_redirects = false
   remember_cookies = false
@@ -27,13 +145,6 @@ resource "betteruptime_monitor" "portal" {
   # cutover; these watch expiry on whatever is actually serving the domain.
   ssl_expiration    = 7
   domain_expiration = 14
-
-  # Solo-operator alerting: email + mobile push, no call/SMS chain. When there
-  # is an on-call rotation, replace these with a betteruptime_policy escalation.
-  email = true
-  push  = true
-  call  = false
-  sms   = false
 }
 
 # The unauthenticated `emisar pack install` path — live ahead of the main
@@ -44,32 +155,50 @@ resource "betteruptime_monitor" "pack_registry" {
 
   pronounceable_name = "emisar pack registry"
 
+  policy_id = betteruptime_policy.incident.id
+
   follow_redirects = false
   remember_cookies = false
   verify_ssl       = true
 
   ssl_expiration    = 7
   domain_expiration = 14
-
-  email = true
-  push  = true
-  call  = false
-  sms   = false
 }
 
 # ── Public status page ────────────────────────────────────────────────────────
 # status.<domain> CNAMEs to Better Stack in dns.tf, and var.caa_issuers already
 # allows Let's Encrypt for it. The custom domain activates once the zone is
 # authoritative (or earlier via the same CNAME at the current registrar); until
-# then the page serves at https://<subdomain>.betteruptime.com.
+# then the page serves at https://emisar.betteruptime.com.
 resource "betteruptime_status_page" "emisar" {
-  company_name = "emisar"
+  company_name = "Emisar"
   company_url  = "https://${var.domain}"
+  contact_url  = "mailto:support@${var.domain}"
 
+  # The logo pair uploaded to Better Stack's CDN from the account (a page-level
+  # asset, not a secret); dark_logo_url serves visitors in dark mode.
+  logo_url      = "https://d1lppblt9t2x15.cloudfront.net/logos/1d18b688f85b4624a44534cd4c7b2110.png"
+  dark_logo_url = "https://d1lppblt9t2x15.cloudfront.net/logos/dc8aa6774ce3e880b99263776c9dad28.png"
+
+  # UTC on purpose: operators are global, and a locale here would leak into the
+  # public repo (house rule — no personal/locale tells in committed values).
   timezone = "UTC"
 
   subdomain     = "emisar"
   custom_domain = "status.${var.domain}"
+
+  # Customers can subscribe to incident updates, and reports are generated
+  # automatically when a monitor goes down — communication starts even before a
+  # human picks up the incident.
+  subscribable      = true
+  automatic_reports = true
+
+  # Show a full quarter of history; hide sub-minute blips (a flapping check is
+  # an alerting concern, not a customer communication).
+  history             = 90
+  min_incident_length = 60
+
+  hide_from_search_engines = false
 
   design = "v2"
   theme  = "light"
@@ -79,6 +208,7 @@ resource "betteruptime_status_page" "emisar" {
 resource "betteruptime_status_page_section" "control_plane" {
   status_page_id = betteruptime_status_page.emisar.id
   name           = "Control plane"
+  position       = 0
 }
 
 resource "betteruptime_status_page_resource" "portal" {
@@ -86,14 +216,18 @@ resource "betteruptime_status_page_resource" "portal" {
   status_page_section_id = betteruptime_status_page_section.control_plane.id
 
   public_name = "Portal, console & MCP API"
+  explanation = "The emisar web console, API, and MCP endpoint at ${var.domain}."
 
   resource_type = "Monitor"
   resource_id   = betteruptime_monitor.portal.id
+
+  widget_type = "history"
 }
 
 resource "betteruptime_status_page_section" "distribution" {
   status_page_id = betteruptime_status_page.emisar.id
   name           = "Distribution"
+  position       = 1
 }
 
 resource "betteruptime_status_page_resource" "pack_registry" {
@@ -101,7 +235,10 @@ resource "betteruptime_status_page_resource" "pack_registry" {
   status_page_section_id = betteruptime_status_page_section.distribution.id
 
   public_name = "Pack registry"
+  explanation = "Serves the public action-pack catalog and tarballs for `emisar pack install` at registry.${var.domain}."
 
   resource_type = "Monitor"
   resource_id   = betteruptime_monitor.pack_registry.id
+
+  widget_type = "history"
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -211,6 +211,17 @@ variable "betterstack_api_token" {
   sensitive   = true
 }
 
+variable "oncall_emails" {
+  type        = list(string)
+  description = "Better Stack on-call rotation, in order — account emails of the people who take incidents (each must already be a Better Stack team member; invites happen out of band). SENSITIVE workspace variable on purpose: the roster AND its size stay out of the public repo. No default — set it in the workspace."
+  sensitive   = true
+
+  validation {
+    condition     = length(var.oncall_emails) >= 1
+    error_message = "oncall_emails needs at least one address — an empty rotation pages no one."
+  }
+}
+
 # ── DNS records (email posture) ───────────────────────────────────────────────
 variable "dmarc_policy" {
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -205,6 +205,12 @@ variable "alert_email" {
   description = "Email address that receives monitoring alerts (uptime, DB CPU/disk). No default on purpose — set per-workspace (Terraform Cloud variable), and make sure the mailbox actually exists: alerts to an unprovisioned alias silently bounce."
 }
 
+variable "betterstack_api_token" {
+  type        = string
+  description = "Better Stack (BetterUptime) API token — the provider credential for the external uptime monitors + public status page (uptime.tf). Same custody as the app secrets: a SENSITIVE Terraform Cloud workspace variable, never a committed value. No default on purpose — the workspace must hold it before any plan runs."
+  sensitive   = true
+}
+
 # ── DNS records (email posture) ───────────────────────────────────────────────
 variable "dmarc_policy" {
   type        = string

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -18,5 +18,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    betteruptime = {
+      source  = "BetterStackHQ/better-uptime"
+      version = "~> 0.21"
+    }
   }
 }

--- a/packs/PUBLISHING.md
+++ b/packs/PUBLISHING.md
@@ -5,7 +5,8 @@ public-read GCS bucket `emisar-pack-registry` (provisioned in
 `infra/packs_registry.tf`; see `infra/README.md`). `emisar pack install` and
 `emisar pack suggest` resolve against it unauthenticated, so every pack
 version/hash ever published must stay installable — publishing **appends**,
-never overwrites history.
+never overwrites history. Public access is GET-only for exact object paths; the
+bucket root is not a supported listing or discovery endpoint.
 
 Both steps run through `packctl`, the maintainer CLI built from `runner/cmd/packctl`
 (`go build -o ../bin/packctl ./cmd/packctl` from `runner/`). It shares the runner's

--- a/portal/config/runtime.exs
+++ b/portal/config/runtime.exs
@@ -42,24 +42,38 @@ import Config
 #   MIXPANEL_GROUPS        — "1"/"true" to also write Mixpanel Group profiles (paid add-on)
 
 if config_env() == :prod do
-  # Structured JSON logs for the fly log drain: every Logger metadata
-  # key ships as a queryable JSON field (no more curated key list to
-  # drift), minus the huge per-request structs. Belt-and-suspenders
-  # redaction of secret-shaped keys — the app never logs raw secrets,
-  # but a future `inspect(changeset)` must not become an incident.
+  # Google Cloud's structured payload recognizes severity, request context,
+  # source locations, traces, and Error Reporting events. The project ID is
+  # injected by the GCE instance template as EMISAR_CLUSTER_PROJECT.
+  gcp_project_id =
+    System.get_env("GOOGLE_CLOUD_PROJECT") ||
+      System.get_env("GOOGLE_PROJECT_ID") ||
+      System.get_env("GCLOUD_PROJECT") ||
+      System.get_env("EMISAR_CLUSTER_PROJECT")
+
+  # Keep application metadata queryable, but never serialize the request and
+  # socket structs. GoogleCloud handles :crash_reason separately so caught
+  # exceptions are sent in the shape Google Cloud Error Reporting recognizes.
   config :logger,
     level: :info,
     handle_otp_reports: true
 
   config :logger, :default_handler,
     formatter:
-      {LoggerJSON.Formatters.Basic,
-       metadata: {:all_except, [:conn, :socket, :crash_reason]},
-       redactors: [
-         LoggerJSON.Redactors.RedactKeys.new(
-           ~w[password token secret authorization api_key key_hash token_hash]
-         )
-       ]}
+      LoggerJSON.Formatters.GoogleCloud.new(
+        project_id: gcp_project_id,
+        service_context: %{
+          service: "emisar",
+          version: System.get_env("RELEASE_VSN") || "unknown"
+        },
+        reported_levels: [:emergency, :alert, :critical, :error],
+        metadata: {:all_except, [:conn, :socket, :crash_reason]},
+        redactors: [
+          LoggerJSON.Redactors.RedactKeys.new(
+            ~w[password token secret authorization api_key key_hash token_hash]
+          )
+        ]
+      )
 
   database_url =
     System.get_env("DATABASE_URL") ||


### PR DESCRIPTION
## Summary
- replace the public `roles/storage.objectViewer` grant with a custom role containing only `storage.objects.get`
- keep exact pack object URLs publicly fetchable while preventing anonymous bucket listing at `registry.emisar.dev/`
- document the GET-only registry contract

## Verification
- `terraform fmt -check -recursive infra`
- `terraform -chdir=infra init -backend=false`
- `terraform -chdir=infra validate`
- `tflint` (from `infra/`)

The Terraform change requires the normal reviewed TFC plan and manual apply. No apply was performed here.
