### PR TITLE
Record the completed Fly-to-GCP cutover in the infra docs

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -2,8 +2,9 @@
 
 Terraform for running emisar on **Google Cloud** to a **SOC 2 Type II** posture
 (compute + Cloud SQL + LB + DNS + secrets + monitoring), adapted from
-`../onlytty/infra`. **Prepared, not applied** — emisar serves from Fly today;
-applying this is a deliberate Fly→GCP migration. Read `README.md` for the shape and
+`../onlytty/infra`. **LIVE — this is production** since the Fly→GCP cutover on
+2026-07-12 (NS delegated to Cloud DNS; DNSSEC DS publication pending NS
+propagation; Fly stays up only until traffic drains). Read `README.md` for the shape and
 `.agent/COMPLIANCE.md` (internal, git-ignored) for the control mapping; this file
 is the rules.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -19,13 +19,14 @@ DNS A/AAAA ──────┤  HTTPS LB (TLS via   ├─► backend (HTTP /r
                           (flow logs)      (egress)     regional HA, PITR backups)
 ```
 
-> **Applied 2026-07-11 — NOT LIVE.** The stack exists in GCP, but emisar still
-> serves from Fly.io: the live nameservers are GoDaddy's, so the zone edits here
-> (apex A/AAAA → the GCP LB, CAA + `pki.goog`) are invisible until NS delegation.
-> The move to GCP is the **Cutover runbook** below, walked in order — the data
-> import and cert pre-provisioning come BEFORE any traffic change. Environment
-> sizing (machine type, node count, DB tier/availability) and the alert address
-> are Terraform Cloud workspace variables, not committed values.
+> **LIVE — production since 2026-07-12.** The Fly→GCP cutover is done: the apex
+> serves from the GCP LB and NS is delegated to Cloud DNS. Two tail steps
+> remain from the runbook below: publish the **DNSSEC DS** at the registrar
+> once NS has propagated everywhere (step 7 — a DS ahead of working delegation
+> takes the domain offline), and decommission Fly once traffic has fully
+> drained. Environment sizing (machine type, node count, DB tier/availability)
+> and the alert address are Terraform Cloud workspace variables, not committed
+> values.
 
 ## What's in it
 
@@ -94,8 +95,8 @@ Better Stack probes the **public hostname** from independent infrastructure,
 runs the **on-call escalation** (notify → wake with a phone call → wake
 everyone, repeating), and hosts the public status page — so detection, paging,
 and customer communication survive an incident in the serving cloud. The
-monitors already watch the Fly deployment today (they follow traffic at
-cutover with no change). Two **sensitive TFC workspace variables** feed it:
+monitors watch the public hostname, which is how they rode the Fly→GCP
+cutover unchanged. Two **sensitive TFC workspace variables** feed it:
 `betterstack_api_token` (the provider credential) and `oncall_emails` (the
 rotation roster — sensitive on purpose, so this public repo reveals neither
 who is on call nor how many people that is; team invites happen in the Better
@@ -105,10 +106,8 @@ history), and default on-call calendar are adopted via `import` blocks — no-op
 after the first apply. The status page serves at
 `https://emisar.betteruptime.com` immediately; `status.emisar.dev` (CNAME in
 `dns.tf`, Let's Encrypt already in `var.caa_issuers`) activates at NS
-delegation — or earlier by adding the same CNAME at GoDaddy, which needs no CAA
-change (the runbook keeps `letsencrypt.org` for Fly). Both monitors are live:
-`registry.emisar.dev` already resolves publicly (it went live independently,
-ahead of the traffic cutover).
+delegation (done 2026-07-12 — the CNAME resolves; Better Stack provisions the
+domain cert on first use). Both monitors are live.
 
 ## Clustering (emisar-specific vs onlytty)
 
@@ -130,6 +129,10 @@ environment in the workspace, then apply; the dials are `machine_type`,
 `alert_email`.
 
 ## Cutover runbook (Fly → GCP, in this order)
+
+> **Executed 2026-07-12** (kept as the record and as the template for any
+> future migration). Remaining: step 7's DS publication after NS propagation,
+> then Fly decommissioning.
 
 The order is the point: the cert can't provision and the data isn't there until
 you make both happen — flipping DNS first means an outage on an empty database.

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -74,38 +74,17 @@ output "status_page_url" {
 }
 
 output "next_steps" {
-  description = "The remaining path to production, in order. Full commands: README «Cutover runbook»."
+  description = "What remains after the 2026-07-12 Fly→GCP cutover, in order."
   value       = <<-EOT
-    1. Merge through the required «Required - CI» check. Main-only CD reuses that
-       exact CI workflow, publishes its tested portal image, uploads this commit's
-       infra configuration to HCP Terraform, and produces the reviewable plan.
-       FIRST publish only: flip the GHCR
-       package to Public, or the unauthenticated instance pull 403s.
-    2. Review the complete saved plan and click «Confirm & Apply» in HCP
-       Terraform. CD never calls apply. The run blocks until the MIG is updated
-       and stable; the LB routes only /readyz-healthy VMs. Rollback is another
-       reviewed plan using a previous digest.
-    3. BEFORE any traffic move (README has the commands):
-         a. import the Fly database into Cloud SQL (freeze Fly writes first);
-         b. optional: add Fly's SECRET_KEY_BASE as a NEW secret version so
-            operator sessions survive the cutover;
-         c. at GoDaddy (still the live DNS): add the FOUR cert DNS-auth CNAMEs
-            (apex, www, mta-sts, registry) + CAA `0 issue "pki.goog"`, wait for
-            the certs to be ACTIVE, then
-            verify: curl --resolve ${var.domain}:443:<lb_ipv4> https://${var.domain}/readyz
-         d. registry.${var.domain} can go live INDEPENDENTLY, before any traffic
-            move: add its A/AAAA at GoDaddy (terraform output
-            pack_registry_godaddy_records), verify
-            https://registry.${var.domain}/v1/catalog.json, then flip the
-            catalog base (packctl --base-url default + EMISAR_PACK_CATALOG_URL —
-            see packs/PUBLISHING.md «Serving domain»)
-    4. Converge traffic at GoDaddy FIRST (avoids a two-database split-brain
-       while NS propagates): lower the A/AAAA TTLs, point A → lb_ipv4 and
-       AAAA → lb_ipv6, watch runners reconnect.
-    5. Delegate NS at the registrar (now a zero-traffic change):
-         ${join("\n         ", google_dns_managed_zone.emisar.name_servers)}
-    6. LAST, after NS resolves everywhere: publish the DNSSEC DS
-       (terraform output dnssec_ds_record); `dig +dnssec ${var.domain}` shows AD.
-       Keep Fly running until traffic drains, then decommission it.
+    Cutover executed 2026-07-12 (README «Cutover runbook» is the record).
+    Remaining:
+    1. After NS delegation resolves everywhere (up to 48 h — verify with
+       `dig +trace ${var.domain} NS`): publish the DNSSEC DS at the registrar
+       (terraform output dnssec_ds_record); `dig +dnssec ${var.domain}` then
+       shows AD. A DS ahead of working delegation takes the domain offline.
+    2. Once traffic and email flows are confirmed drained off Fly:
+       decommission the Fly app (its database was imported at cutover).
+    3. Ongoing: ramp DMARC (var.dmarc_policy none → quarantine → reject) and
+       MTA-STS (testing → enforce) on clean reports — dns.tf comments.
   EOT
 }

--- a/infra/uptime.tf
+++ b/infra/uptime.tf
@@ -4,8 +4,8 @@
 # alert path in one stroke. Better Stack probes from independent infrastructure,
 # runs the on-call escalation, and hosts the public status page — so detection,
 # paging, and customer communication all survive the outage they report on. It
-# also monitors the PUBLIC hostname, which means it watches the Fly deployment
-# today and follows traffic to GCP at cutover with no change here.
+# monitors the PUBLIC hostname — which is how it watched the Fly deployment
+# and rode the 2026-07-12 Fly→GCP cutover without a change here.
 #
 # The account predates this config, so the pre-existing resources are adopted
 # via import blocks (no-ops after the first apply) instead of being recreated —
@@ -141,14 +141,13 @@ resource "betteruptime_monitor" "portal" {
   remember_cookies = false
   verify_ssl       = true
 
-  # The GCP-side cert-renewal alert (monitoring.tf) only observes traffic after
-  # cutover; these watch expiry on whatever is actually serving the domain.
+  # Independent of the GCP-side cert-renewal alert (monitoring.tf): these watch
+  # expiry on whatever is actually serving the domain, from outside.
   ssl_expiration    = 7
   domain_expiration = 14
 }
 
-# The unauthenticated `emisar pack install` path — live ahead of the main
-# cutover (the registry went public independently, per the runbook).
+# The unauthenticated `emisar pack install` path.
 resource "betteruptime_monitor" "pack_registry" {
   url          = "https://registry.${var.domain}/v1/catalog.json"
   monitor_type = "status"
@@ -166,10 +165,9 @@ resource "betteruptime_monitor" "pack_registry" {
 }
 
 # ── Public status page ────────────────────────────────────────────────────────
-# status.<domain> CNAMEs to Better Stack in dns.tf, and var.caa_issuers already
-# allows Let's Encrypt for it. The custom domain activates once the zone is
-# authoritative (or earlier via the same CNAME at the current registrar); until
-# then the page serves at https://emisar.betteruptime.com.
+# status.<domain> CNAMEs to Better Stack in dns.tf (resolving since the zone
+# went authoritative), and var.caa_issuers already allows Let's Encrypt for it;
+# the page also serves at https://emisar.betteruptime.com.
 resource "betteruptime_status_page" "emisar" {
   company_name = "Emisar"
   company_url  = "https://${var.domain}"

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -3,8 +3,9 @@
 # Container-Optimized OS instances running the portal image from public GHCR,
 # backed by private-IP Cloud SQL Postgres, with Secret Manager, least-priv IAM,
 # audit logging, monitoring, and the authoritative Cloud DNS zone (DNSSEC).
-# Adapted from ../onlytty/infra; PREPARED, NOT APPLIED — emisar serves from
-# Fly.io today, and applying this is the deliberate Fly→GCP migration (README).
+# Adapted from ../onlytty/infra. LIVE — serving production since the Fly→GCP
+# cutover on 2026-07-12 (README «Cutover runbook» is the record; the DNSSEC DS
+# publication is the one remaining step, gated on NS propagation).
 
 terraform {
   required_version = ">= 1.10" # `project` in the cloud{} workspaces block


### PR DESCRIPTION
The stack is production since 2026-07-12: the apex serves from the GCP LB and NS is delegated to Cloud DNS (verified at the TLD: `ns-cloud-e*.googledomains.com`; `/readyz` 200 via the LB with a pki.goog cert). This sweeps every "prepared, not applied / serves from Fly" claim across the infra docs:

- `AGENTS.md` / README callout: **LIVE — this is production**, with the two remaining tail steps called out.
- Cutover runbook: marked executed 2026-07-12, kept as the record/template.
- `next_steps` output now carries only what remains: publish the DNSSEC DS after NS propagation (step 7 — a DS ahead of working delegation takes the domain offline), decommission Fly after drain, DMARC/MTA-STS ramp.
- `uptime.tf` comments updated (the monitors probe the public hostname and rode the cutover unchanged).

Docs/comments and one output string only — no resource changes. Gate green (fmt/validate/tflint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)