### PR TITLE
Drop plan-gated status page subscriptions

### DIFF
--- a/infra/uptime.tf
+++ b/infra/uptime.tf
@@ -185,10 +185,11 @@ resource "betteruptime_status_page" "emisar" {
   subdomain     = "emisar"
   custom_domain = "status.${var.domain}"
 
-  # Customers can subscribe to incident updates, and reports are generated
-  # automatically when a monitor goes down — communication starts even before a
-  # human picks up the incident.
-  subscribable      = true
+  # Reports are generated automatically when a monitor goes down —
+  # communication starts even before a human picks up the incident.
+  # (`subscribable` is deliberately absent: subscription settings are gated to
+  # a paid Better Stack tier — the API 403s on it — so it stays at the account
+  # default until the plan supports it.)
   automatic_reports = true
 
   # Show a full quarter of history; hide sub-minute blips (a flapping check is


### PR DESCRIPTION
The Better Stack apply (run-x3yHpaCEFgto7Jc9) failed on two things: `subscribable` is gated to a paid tier (API 403), and the rotation email wasn't a Better Stack team member. This removes `subscribable` (with a why-comment); the roster fix was a workspace-variable value change (now `andrew@emisar.dev`, the actual team member, and the variable is flipped to sensitive).

Everything else on the status page (automatic reports, UTC, 90-day history, `support@` contact fix) is accepted by the current tier — verified with a direct API PATCH returning 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)