### PR TITLE
Cut v0.24.0

### DIFF
--- a/.github/workflows/mcp-registry-release.yml
+++ b/.github/workflows/mcp-registry-release.yml
@@ -53,11 +53,13 @@ jobs:
       - name: Require successful CI for tagged commit
         run: |
           set -euo pipefail
+          # PR commits carry the check as "Required - CI"; on main the same job
+          # arrives via cd.yml's workflow_call and registers as "CI / Required - CI".
           source_sha=$(git rev-parse HEAD)
           conclusion=$(gh api \
             -H 'Accept: application/vnd.github+json' \
             "repos/${GITHUB_REPOSITORY}/commits/${source_sha}/check-runs?per_page=100" \
-            --jq '[.check_runs[] | select(.name == "Required - CI" and .status == "completed")] | sort_by(.completed_at) | last | .conclusion // "missing"')
+            --jq '[.check_runs[] | select((.name == "Required - CI" or .name == "CI / Required - CI") and .status == "completed")] | sort_by(.completed_at) | last | .conclusion // "missing"')
           test "$conclusion" = success || {
             echo "::error::tagged commit has no successful Required - CI check (got '$conclusion')"
             exit 1

--- a/portal/apps/emisar_web/lib/emisar_web/changelog.ex
+++ b/portal/apps/emisar_web/lib/emisar_web/changelog.ex
@@ -13,10 +13,10 @@ defmodule EmisarWeb.Changelog do
     %{
       date: ~D[2026-07-12],
       slug: "release-integrity-and-pack-registry",
-      title: "Safer releases and a reliable pack registry",
+      title: "Hardened hosting, safer releases, and a public status page",
       tag: "v0.24.0",
       summary:
-        "Portal releases now publish the exact image exercised by CI, binary releases are immutable and reproducible, and production plans queue in order without replacing an operator's pending review. Pack publication gained fresh mutable pointers, generation-specific verification, and end-to-end tarball checks; until the vendor-neutral registry hostname is live, every catalog and redirect uses the working GCS endpoint instead of sending installers to a dead host."
+        "The hosted platform moved to hardened cloud infrastructure with zero-downtime rollouts, a private-network database, and independent external monitoring behind a public status page at status.emisar.dev. Portal releases now publish the exact image exercised by CI, binary releases are immutable and reproducible, and production plans queue in order without replacing an operator's pending review. The pack registry serves from its own hostname, registry.emisar.dev, with anonymous access narrowed to exact object reads, generation-specific verification, and end-to-end tarball checks."
     },
     %{
       date: ~D[2026-07-07],

--- a/portal/apps/emisar_web/test/emisar_web/marketing_test.exs
+++ b/portal/apps/emisar_web/test/emisar_web/marketing_test.exs
@@ -622,10 +622,11 @@ defmodule EmisarWeb.MarketingTest do
       assert html =~ "The marketing site, rebuilt"
       assert html =~ "More reliable background work and a cleaner runner setup"
       assert html =~ "Annual billing, Team-owned SSO, and safer input handling"
+      assert html =~ "Hardened hosting, safer releases, and a public status page"
       # Product release tags — the commit history, the tags, and the changelog
       # all line up (newest and oldest both rendered).
       assert html =~ "v0.1.0"
-      assert html =~ "v0.23.0"
+      assert html =~ "v0.24.0"
       assert html =~ "v0.15.0"
 
       # The first-party RSS feed, the repo, and the "see all" out-link.

--- a/portal/apps/emisar_web/test/emisar_web/mcp_registry_test.exs
+++ b/portal/apps/emisar_web/test/emisar_web/mcp_registry_test.exs
@@ -27,7 +27,10 @@ defmodule EmisarWeb.MCPRegistryTest do
 
     assert String.length(descriptor["description"]) <= 100
 
-    assert descriptor["version"] == "0.23.0"
+    # The product line has ONE version source (portal/VERSION); server.json
+    # rides it, and the publish workflow re-stamps it from the release tag.
+    product_version = @repo_root |> Path.join("portal/VERSION") |> File.read!() |> String.trim()
+    assert descriptor["version"] == product_version
 
     assert descriptor["remotes"] == [
              %{

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.emisar/emisar",
   "title": "emisar",
   "description": "Governed MCP for real infrastructure actions — gated, approved, audited.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "websiteUrl": "https://emisar.dev",
   "repository": {
     "url": "https://github.com/andrewdryga/emisar",


### PR DESCRIPTION
Release housekeeping for v0.24.0 (version + LICENSE were already rolled in #2):

- Changelog entry updated to cover the full window: leads with the infrastructure migration, zero-downtime rollouts, and the public status page at status.emisar.dev; drops the now-false "registry hostname not yet live" caveat; registry + release-integrity themes kept.
- Marketing test asserts the new newest entry (title + v0.24.0).
- `server.json` bumped to 0.24.0; its test now asserts against `portal/VERSION` (single source) instead of a pinned literal, so version bumps can't break it again.
- **Publish-workflow fix:** tag verification matched the check name `Required - CI` exactly, but CD-called CI registers it on main commits as `CI / Required - CI` — every release tag would have been rejected. Now accepts both.

After merge: signed `v0.24.0` tag at the squash commit → triggers the MCP registry listing publish → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)