### PR TITLE
feat(infra): park Livebook compute instead of forcing a guarded destroy

### DIFF
--- a/infra/livebook.tf
+++ b/infra/livebook.tf
@@ -75,6 +75,13 @@ resource "google_compute_instance" "livebook" {
   tags                      = ["emisar-livebook"]
   allow_stopping_for_update = true
 
+  # Park dial: TERMINATED stops compute + license billing while the disks,
+  # secret, database principal, and LB/IAP wiring all survive, so turning the
+  # workbench off day-to-day is a one-attribute stop — retiring it outright
+  # (livebook_enabled = false) deliberately remains a reviewed destroy guarded
+  # by prevent_destroy on the durable pieces.
+  desired_status = var.livebook_running ? "RUNNING" : "TERMINATED"
+
   # Deliberately omit cluster_name: portal libcluster must never auto-discover
   # this full-trust debugging node.
   labels = {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -180,8 +180,14 @@ variable "mailer_from_email" {
 # ── Livebook admin workbench ─────────────────────────────────────────────────
 variable "livebook_enabled" {
   type        = bool
-  description = "Deploy the private Livebook admin workbench behind Google IAP. Enabling it requires release_cookie_ready and livebook_iap_iam_user."
+  description = "Deploy the private Livebook admin workbench behind Google IAP. Enabling it requires release_cookie_ready and livebook_iap_iam_user. To turn a provisioned workbench off day-to-day, set livebook_running = false instead — flipping this back to false plans a full teardown, which prevent_destroy on the data disk, secret, and database principal deliberately blocks until those are explicitly retired."
   default     = false
+}
+
+variable "livebook_running" {
+  type        = bool
+  description = "Desired power state of the provisioned Livebook workbench. false parks it: the VM stops, ending compute and license billing, while its disks (notebooks), secret, database principal, and LB/IAP wiring remain so resuming is a restart, not a rebuild. Only read when livebook_enabled is true."
+  default     = true
 }
 
 variable "livebook_machine_type" {


### PR DESCRIPTION
Flipping `livebook_enabled = false` plans a full teardown and dies on `prevent_destroy` (data disk, SECRET_KEY_BASE secret, Cloud SQL principal) — working as designed for *retirement*, but there was no cheap way to just turn the thing off.

## Change
New **`livebook_running`** (bool, default `true`) drives `desired_status` on the instance:

- `livebook_running = false` → VM stops (`TERMINATED`): compute + COS license billing end; the data disk (notebooks), boot disk, secret, database principal, firewall, and LB/IAP wiring all stay. Resume = flip back to `true`.
- `livebook_enabled = false` keeps its meaning: full retirement, still deliberately blocked by `prevent_destroy` until the durable pieces are explicitly retired.

One attribute changes in the plan; nothing is destroyed. `desired_status` verified against the pinned provider (7.39.0).

## Verification
`terraform fmt -check -recursive`, `terraform validate`, `tflint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)