### PR TITLE
refactor(infra): park Livebook by absence, not power state

### DIFF
--- a/.agent/rules/infra-optional-resource-splat-refs.md
+++ b/.agent/rules/infra-optional-resource-splat-refs.md
@@ -1,0 +1,29 @@
+# infra: consumers of optional resources use splat, never a hard index
+
+**Rule.** When resource B references a count-gated resource A, and B can exist while A does not (B's count condition is broader than A's, or B is unconditional), the reference must degrade with A's absence — `A[*].attr` (splat, yielding `[]`) or an expression guarded by A's own condition — never `A[0].attr`.
+
+**Why.** A hard `[0]` bakes "A always exists whenever B does" into the graph. The first lifecycle change that lets A reach count 0 independently (parking a VM, downscoping an environment) then fails at plan time or forces reference surgery across files — turning a one-variable flip into a refactor. Splat keeps absence a first-class state the graph already handles.
+
+✅ Good — the LB graph outlives the parked instance; membership degrades to empty:
+
+```hcl
+resource "google_compute_instance_group" "livebook" {
+  count     = var.livebook_enabled ? 1 : 0
+  instances = google_compute_instance.livebook[*].self_link
+}
+```
+
+❌ Bad — plan explodes the moment the instance's count can be 0 while the group's is 1:
+
+```hcl
+resource "google_compute_instance_group" "livebook" {
+  count     = var.livebook_enabled ? 1 : 0
+  instances = [google_compute_instance.livebook[0].self_link]
+}
+```
+
+Same-lifecycle references are fine and idiomatic: `A[0]` where the consumer's count condition is identical to A's, or strictly implies it (e.g. the instance gated on `enabled && running` reading the data disk gated on `enabled`) — absence can never diverge there.
+
+**Sweep target.** `grep -nE '\[0\]\.' infra/*.tf`, then for each hit compare the consumer's count condition with the target's; fix any consumer that can outlive its target. Swept 2026-07-17: the instance-group membership was the only divergent-lifecycle hit.
+
+**How it's enforced.** Judgment plus the plan itself — no CI source grep (AGENTS.md creed #8 bans placement-rule greps). Exercising the park/enable dials in a plan is the mechanical check: a violation fails immediately at plan time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ goes through `coop fork` (each fork is its own clone) — never two writers in o
 
 - **Content:** [plain, specific prose](.agent/rules/content-plain-specific-prose.md) — write for one known reader, make every sentence earn its place, and adapt the density and tone to the surface instead of falling back to corporate or generated language.
 - **Content:** [bounded autonomy leads the positioning](.agent/rules/content-position-bounded-autonomy.md) — lead with the agent work the operator can safely leave running; earn that promise with declared actions, the pack catalog, and enforcement, while keeping approvals and audit in their supporting role.
+- **Infra:** [optional-resource refs use splat, never a hard index](.agent/rules/infra-optional-resource-splat-refs.md) — a consumer that can outlive a count-gated resource references it as `A[*].attr` so absence degrades to `[]`; `A[0].attr` bakes in existence and turns a lifecycle flip into graph surgery.
 
 When the user corrects something — a naming call, a "use X not Y," a structural nit — it is a **rule**, not a one-off fix. In the **same change**:
 

--- a/infra/livebook.tf
+++ b/infra/livebook.tf
@@ -67,20 +67,19 @@ resource "google_compute_disk" "livebook_data" {
 }
 
 resource "google_compute_instance" "livebook" {
-  count = var.livebook_enabled ? 1 : 0
+  # Existence is the park dial: parking (livebook_running = false) deletes the
+  # VM and its auto_delete boot disk, so a parked workbench bills only the data
+  # disk. Notebooks/config live on that disk and cloud-init rebuilds the rest,
+  # so resume is a clean re-provision — while retiring the workbench outright
+  # (livebook_enabled = false) deliberately remains a reviewed destroy guarded
+  # by prevent_destroy on the durable pieces.
+  count = var.livebook_enabled && var.livebook_running ? 1 : 0
 
   name                      = "emisar-livebook"
   zone                      = var.zones[0]
   machine_type              = var.livebook_machine_type
   tags                      = ["emisar-livebook"]
   allow_stopping_for_update = true
-
-  # Park dial: TERMINATED stops compute + license billing while the disks,
-  # secret, database principal, and LB/IAP wiring all survive, so turning the
-  # workbench off day-to-day is a one-attribute stop — retiring it outright
-  # (livebook_enabled = false) deliberately remains a reviewed destroy guarded
-  # by prevent_destroy on the durable pieces.
-  desired_status = var.livebook_running ? "RUNNING" : "TERMINATED"
 
   # Deliberately omit cluster_name: portal libcluster must never auto-discover
   # this full-trust debugging node.
@@ -156,9 +155,12 @@ resource "google_compute_instance" "livebook" {
 resource "google_compute_instance_group" "livebook" {
   count = var.livebook_enabled ? 1 : 0
 
-  name      = "emisar-livebook"
-  zone      = var.zones[0]
-  instances = [google_compute_instance.livebook[0].self_link]
+  name = "emisar-livebook"
+  zone = var.zones[0]
+  # Splat, not [0]: the group (and the LB graph above it) outlives the parked
+  # instance, so membership must degrade to empty rather than dangle a hard
+  # reference (.agent/rules/infra-optional-resource-splat-refs.md).
+  instances = google_compute_instance.livebook[*].self_link
 
   named_port {
     name = "livebook"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -186,7 +186,7 @@ variable "livebook_enabled" {
 
 variable "livebook_running" {
   type        = bool
-  description = "Desired power state of the provisioned Livebook workbench. false parks it: the VM stops, ending compute and license billing, while its disks (notebooks), secret, database principal, and LB/IAP wiring remain so resuming is a restart, not a rebuild. Only read when livebook_enabled is true."
+  description = "Whether the provisioned Livebook workbench's VM exists. false parks it: the VM and its boot disk are deleted, ending all compute billing, while the data disk (notebooks), secret, database principal, and LB/IAP wiring remain; resuming re-provisions the VM from cloud-init against the surviving data disk. Only read when livebook_enabled is true."
   default     = true
 }
 


### PR DESCRIPTION
Follow-up to #19 per founder direction: parked must mean **zero compute spend including the boot disk** — worth the destroy/create churn.

## Changes
- `livebook_running = false` now **deletes** the VM (`count = enabled && running`) and its `auto_delete` boot disk instead of stopping it. A parked workbench bills only the data disk; resume re-provisions from cloud-init against the surviving data disk. `desired_status` is gone (dead with this model).
- **Root cause fixed**: the instance group hard-indexed the instance (`[google_compute_instance.livebook[0].self_link]`), baking "always exists" into the LB graph. Now `instances = google_compute_instance.livebook[*].self_link` — membership degrades to `[]`, the group/backends/URL map never need surgery.
- **Correction → rule** (taste pipeline): `.agent/rules/infra-optional-resource-splat-refs.md` + AGENTS.md index entry — a consumer that can outlive a count-gated resource references it with a splat, never `[0]`.
- **Sweep**: every `[0].` reference in `infra/` classified; the group membership was the only divergent-lifecycle hit (rest are same-condition or consumer-implies-target, the safe directions).

## Behavior when parked
LB host rule, IAP, backends, health check all remain (free); the livebook host serves 502 after IAP auth. Empty unmanaged groups are valid backend targets (`instances` is optional+computed in provider 7.39.0).

## Verification
`terraform fmt -check -recursive`, `terraform validate`, `tflint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)