### PR TITLE
feat(infra): make LB request logging a dial, off by default

### DIFF
--- a/infra/lb.tf
+++ b/infra/lb.tf
@@ -151,8 +151,8 @@ resource "google_compute_backend_service" "livebook" {
   }
 
   log_config {
-    enable      = true
-    sample_rate = 1.0
+    enable      = var.lb_request_log_sampling > 0
+    sample_rate = var.lb_request_log_sampling
   }
 
   backend {
@@ -177,8 +177,8 @@ resource "google_compute_backend_service" "livebook_public" {
   health_checks                   = [google_compute_health_check.livebook[0].id]
 
   log_config {
-    enable      = true
-    sample_rate = 1.0
+    enable      = var.lb_request_log_sampling > 0
+    sample_rate = var.lb_request_log_sampling
   }
 
   backend {
@@ -249,10 +249,13 @@ resource "google_compute_backend_service" "app" {
   connection_draining_timeout_sec = 120
   health_checks                   = [google_compute_health_check.readiness.id]
 
-  # Structured request logging at the edge (SOC 2: access log / forensics).
+  # Edge request log — the record of traffic the app never sees (probes, 502
+  # windows, blocked paths, the client-IP chain). A cost/forensics dial, NOT a
+  # claimed SOC 2 control: the LB 5xx/503 alerts read the platform request_count
+  # metric, not this log, so 0 (off) breaks no alert and no compliance claim.
   log_config {
-    enable      = true
-    sample_rate = 1.0
+    enable      = var.lb_request_log_sampling > 0
+    sample_rate = var.lb_request_log_sampling
   }
 
   backend {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -69,6 +69,17 @@ variable "vpc_flow_log_sampling" {
   }
 }
 
+variable "lb_request_log_sampling" {
+  type        = number
+  description = "External Application Load Balancer request-log sampling rate (0.0–1.0), applied to every backend. Forensics-vs-cost dial for the edge access log — the only record of traffic the app never sees (probes, 502 windows, blocked paths, the client-IP chain). 0 disables request logging; 1.0 logs every request. Not a claimed SOC 2 control, and the LB 5xx/503 alerts read the platform request_count metric rather than this log, so either extreme is safe."
+  default     = 0
+
+  validation {
+    condition     = var.lb_request_log_sampling >= 0 && var.lb_request_log_sampling <= 1
+    error_message = "lb_request_log_sampling must be between 0.0 and 1.0."
+  }
+}
+
 # ── Pack registry (the one public-read bucket) ────────────────────────────────
 variable "pack_registry_bucket" {
   type        = string


### PR DESCRIPTION
Turns off external ALB request logging **for now**, done as a dial (mirrors `vpc_flow_log_sampling`) so resuming is a flag flip, not a code change.

## Change
New **`lb_request_log_sampling`** (number, default `0` = off, validated 0–1) drives `enable` + `sample_rate` on all three backends (`app`, `livebook`, `livebook_public`):

```hcl
log_config {
  enable      = var.lb_request_log_sampling > 0
  sample_rate = var.lb_request_log_sampling
}
```

`0` → `(enable=false, sample_rate=0)`, the canonical disabled state; any value >0 → `(true, that rate)`. The invariant `enable ⇔ sample_rate>0` holds, so no cross-field API error is possible.

## Why it's safe to turn off
- **Not a SOC 2-claimed control** — `.agent/COMPLIANCE.md` maps pgAudit, the locked evidence bucket, uptime, and the log-metric alerts; it never claimed edge/LB request logging.
- **No alert depends on it** — the LB 5xx-ratio and 503 alerts read `loadbalancing.googleapis.com/https/request_count` (a platform metric, independent of request logging); every log-based metric reads `gce_instance` app logs.
- Corrects the app backend's stale `# SOC 2: access log / forensics` comment to reflect that.

## Verification
`terraform fmt -check -recursive`, `terraform validate`, `tflint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)