### PR TITLE
fix(portal): stop health-check probes from flooding the app log

### DIFF
--- a/portal/apps/emisar_web/lib/emisar_web/endpoint.ex
+++ b/portal/apps/emisar_web/lib/emisar_web/endpoint.ex
@@ -57,7 +57,15 @@ defmodule EmisarWeb.Endpoint do
     cookie_key: "request_logger"
 
   plug Plug.RequestId
-  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+
+  # The GCP load balancer probes /readyz and the auto-healer probes /healthz on
+  # every instance every few seconds; logging each request's start/stop at :info
+  # buried the app log in health-check noise. The :log hook skips just those two
+  # paths (endpoint_log_level/1 below) — every other request still logs at :info,
+  # so we keep the operational/audit signal a lower global level would discard.
+  plug Plug.Telemetry,
+    event_prefix: [:phoenix, :endpoint],
+    log: {__MODULE__, :endpoint_log_level, []}
 
   # We use a path-bounded body reader where a security boundary needs exact
   # bytes: Paddle verifies its HMAC, while MCP rejects ambiguous JSON and checks
@@ -76,6 +84,12 @@ defmodule EmisarWeb.Endpoint do
   plug Plug.Head
   plug :session
   plug EmisarWeb.Router
+
+  # Plug.Telemetry :log hook (see the plug above). false skips request logging
+  # for the health probes; every other path logs at :info.
+  def endpoint_log_level(%Plug.Conn{path_info: ["healthz"]}), do: false
+  def endpoint_log_level(%Plug.Conn{path_info: ["readyz"]}), do: false
+  def endpoint_log_level(%Plug.Conn{}), do: :info
 
   defp session(conn, _opts) do
     session_config = Plug.Session.init(session_options())


### PR DESCRIPTION
`GET /healthz` + `Sent 200` were dominating the Cloud Logging app stream — the GCP LB (`/readyz`) and auto-healer (`/healthz`) probe every instance every few seconds, and Phoenix logs each request's endpoint start/stop at `:info`.

## Why not just set the log level to `:warn`
This is a security control plane — `:info` is where the operational/audit signal lives (sign-ins, run dispatches, policy changes). Dropping the whole app to `:warn` to kill health-check noise would blind exactly the logs you'd want during an incident.

## Fix
The endpoint's `Plug.Telemetry` gets a dynamic `:log` hook (Phoenix's documented pattern) that returns `false` for the two health paths and `:info` for everything else:

```elixir
plug Plug.Telemetry,
  event_prefix: [:phoenix, :endpoint],
  log: {__MODULE__, :endpoint_log_level, []}

def endpoint_log_level(%Plug.Conn{path_info: ["healthz"]}), do: false
def endpoint_log_level(%Plug.Conn{path_info: ["readyz"]}), do: false
def endpoint_log_level(%Plug.Conn{}), do: :info
```

The router already scoped health routes as "no logging", but the noise is endpoint-level telemetry, which runs before the router — so it had to be silenced here. Stops the noise at the source rather than paying to store then filter it.

## Verification
`mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo` (698 files, 0 issues), and the full test-output suite (4,697 tests, clean output) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)