### PR TITLE
Make the pack behavior matrix fast

### DIFF
--- a/.agent/kb/rules/packs-fixtures-match-the-isolated-nonroot-sut.md
+++ b/.agent/kb/rules/packs-fixtures-match-the-isolated-nonroot-sut.md
@@ -20,6 +20,15 @@ up itself. Three shapes to recognize:
    opens the pid file and creates its cache temp dirs). Either declare
    `runner_user: root` with a `runner_reason`, or widen exactly the paths the
    fixture owns — never both, and never by making the whole SUT privileged.
+4. **A health check dials the address the case will use.** An image that seeds
+   through `docker-entrypoint-initdb.d` runs a *temporary* daemon reachable only
+   on loopback or a unix socket, then stops it and starts the real one. A check
+   pointed at loopback passes against that temporary daemon, so `up --wait`
+   returns healthy and the case gets `ECONNREFUSED` over the network. Point the
+   check at the container's own routable address — `"$$(hostname -i)"` in
+   Compose — which only the real daemon binds. Cadence hides this: a coarse
+   `interval` polls late enough to miss the window by luck, so tightening
+   readiness is what exposes it.
 
 **Why.** The isolation hardening was the point: a case that shares a server with
 its neighbours proves nothing about the action, and a root runner hides every
@@ -54,6 +63,15 @@ environment:
   runner_reason: Postfix reserves the postfix command itself for the superuser.
 ```
 
+```yaml
+# compose.yaml — readiness proves the daemon a case can actually reach
+healthcheck:
+  test: ["CMD-SHELL", "pg_isready -h \"$$(hostname -i)\" -U postgres"]
+  interval: 5s
+  start_period: 30s
+  start_interval: 1s
+```
+
 **❌ Bad**
 
 ```yaml
@@ -68,6 +86,12 @@ environment:
     stdout_contains: [packtest.orders]
 ```
 
+```yaml
+# reports healthy against the entrypoint's temporary loopback-only daemon
+healthcheck:
+  test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+```
+
 **How it's enforced.** CI, and only CI — the pack behavior matrix on Linux is
 the authority for this class, so push the fix and read the job rather than
 trusting a local pass. `packtest` already refuses a case with no semantic
@@ -75,5 +99,6 @@ assertion, so weakening an assertion to `stdout_not_empty` is not an escape
 hatch: fix the environment instead. Sweep signal: an IP address, hostname, or
 port literal inside `expect:` that the fixture does not set; an action whose
 name implies cumulative counters (`top`, `*_stats`, profilers) with no
-`arrange:`; and a case whose command is documented as superuser-only but
-declares no `runner_user`.
+`arrange:`; a case whose command is documented as superuser-only but declares
+no `runner_user`; and a `healthcheck.test` naming `localhost`, `127.0.0.1`, or
+a bare socket on an image that seeds through `docker-entrypoint-initdb.d`.

--- a/.agent/kb/rules/packs-fixtures-match-the-isolated-nonroot-sut.md
+++ b/.agent/kb/rules/packs-fixtures-match-the-isolated-nonroot-sut.md
@@ -29,6 +29,13 @@ up itself. Three shapes to recognize:
    Compose — which only the real daemon binds. Cadence hides this: a coarse
    `interval` polls late enough to miss the window by luck, so tightening
    readiness is what exposes it.
+5. **A probe must not out-race the entrypoint.** `start_interval` polls during
+   the start period, and a check that is itself a client of the service can
+   create state the entrypoint owns — an Erlang health check run one second in
+   writes `.erlang.cookie` before the entrypoint does, and the server it then
+   starts cannot read the file. Give a check that writes anything a probe no
+   earlier than the entrypoint's own setup: `start_period` alone still polls at
+   `interval`, which is the safe cadence for this class.
 
 **Why.** The isolation hardening was the point: a case that shares a server with
 its neighbours proves nothing about the action, and a root runner hides every
@@ -101,4 +108,5 @@ port literal inside `expect:` that the fixture does not set; an action whose
 name implies cumulative counters (`top`, `*_stats`, profilers) with no
 `arrange:`; a case whose command is documented as superuser-only but declares
 no `runner_user`; and a `healthcheck.test` naming `localhost`, `127.0.0.1`, or
-a bare socket on an image that seeds through `docker-entrypoint-initdb.d`.
+a bare socket on an image that seeds through `docker-entrypoint-initdb.d`; and
+a sub-second `start_interval` on a check that writes state rather than reads it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,6 +680,14 @@ jobs:
           tags: ${{ steps.tools.outputs.image }}
           cache-from: type=gha,scope=packtest-tools
 
+      # setup-buildx-action leaves its container-driver builder selected for the
+      # rest of the job, and that builder has its own image store. A pack whose
+      # client image starts FROM the shared one would resolve that base against
+      # the registry and fail; the daemon is where the restore just loaded it.
+      - name: Build against the daemon's image store
+        if: steps.tools.outputs.image != ''
+        run: docker buildx use default
+
       - name: Exercise pack behavior
         run: ./run test packs "$PACK" --shard "$SHARD"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,7 +627,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 4
+      # 57 rows of mostly-idle Docker waits. The cap was low to spare Docker
+      # Hub, which reusing the shared client image relieved: a row now pulls
+      # its own SUT rather than nine images it mostly never runs.
+      max-parallel: 12
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.pack_behavior) }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,7 +620,7 @@ jobs:
           cache-to: type=gha,mode=min,scope=packtest-tools
 
   pack-behavior:
-    name: Packs - Behavior (${{ matrix.pack }} ${{ matrix.version }})
+    name: Packs - Behavior (${{ matrix.pack }} ${{ matrix.version }}${{ matrix.shards > 1 && format(' shard {0}/{1}', matrix.shard, matrix.shards) || '' }})
     needs: [changes, pack-tools]
     if: needs.changes.outputs.pack_behavior != '[]'
     runs-on: ubuntu-latest
@@ -635,6 +635,7 @@ jobs:
       PACK: ${{ matrix.pack }}
       PACKTEST_VERSION: ${{ matrix.version }}
       PACKTEST_DIGEST: ${{ matrix.digest }}
+      SHARD: ${{ matrix.shard }}/${{ matrix.shards }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -677,13 +678,13 @@ jobs:
           cache-from: type=gha,scope=packtest-tools
 
       - name: Exercise pack behavior
-        run: ./run test packs "$PACK"
+        run: ./run test packs "$PACK" --shard "$SHARD"
 
       - name: Upload failed pack report
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: pack-behavior-${{ matrix.pack }}-${{ matrix.version }}
+          name: pack-behavior-${{ matrix.pack }}-${{ matrix.version }}-${{ matrix.shard }}
           path: dev/test-packs/reports
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,9 +577,27 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: tools/go.mod
-          cache: true
-          cache-dependency-path: tools/go.*
+          go-version-file: runner/go.mod
+          cache: false
+
+      # setup-go's cache is keyed on go.sum alone and shared with every other
+      # Go job, so whichever saves it first decides which build flags the
+      # restored objects carry. The behavior rows want these ones.
+      - name: Cache the behavior build objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
+
+      - name: Warm the behavior build objects
+        env:
+          GOOS: linux
+          CGO_ENABLED: "0"
+        run: |
+          go -C runner build -trimpath -o /dev/null .
+          go -C tools build -trimpath -o /dev/null ./cmd/packtest
 
       - id: tools
         name: Resolve the shared client image
@@ -627,10 +645,17 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: runner/go.mod
-          cache: true
-          cache-dependency-path: |
-            runner/go.sum
-            tools/go.sum
+          cache: false
+
+      # Read-only: pack-tools wrote this entry with the flags packTest's
+      # preflight cross-compiles under, so the rows link rather than rebuild.
+      - name: Restore the behavior build objects
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
 
       # Empty for a pack that ships its own client image, which then needs
       # neither the builder nor the restore.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,9 +560,50 @@ jobs:
       - name: Validate packs and cross-language hashes
         run: ./run check packs
 
+  pack-tools:
+    name: Packs - Behavior client image
+    needs: changes
+    if: needs.changes.outputs.pack_behavior != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: tools/go.mod
+          cache: true
+          cache-dependency-path: tools/go.*
+
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # One writer for the whole matrix. Every behavior row restores this entry
+      # instead of pulling eight servers to extract one binary from each, and
+      # letting the rows write it back would mean dozens of concurrent uploads
+      # of the same 2GB image the first time the Dockerfile changes.
+      - name: Populate the shared client image cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
+          cache-to: type=gha,mode=min,scope=packtest-tools
+
   pack-behavior:
     name: Packs - Behavior (${{ matrix.pack }} ${{ matrix.version }})
-    needs: changes
+    needs: [changes, pack-tools]
     if: needs.changes.outputs.pack_behavior != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -590,6 +631,25 @@ jobs:
           cache-dependency-path: |
             runner/go.sum
             tools/go.sum
+
+      # Empty for a pack that ships its own client image, which then needs
+      # neither the builder nor the restore.
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image "$PACK")" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.tools.outputs.image != ''
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Restore the shared client image
+        if: steps.tools.outputs.image != ''
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
 
       - name: Exercise pack behavior
         run: ./run test packs "$PACK"
@@ -783,7 +843,7 @@ jobs:
   ci-gate:
     name: Required - CI
     if: always()
-    needs: [changes, portal, portal-image, mcp-listing, go, packs, pack-behavior, signing-e2e, sso-e2e, infra, dep-age, actionlint]
+    needs: [changes, portal, portal-image, mcp-listing, go, packs, pack-tools, pack-behavior, signing-e2e, sso-e2e, infra, dep-age, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -797,6 +857,7 @@ jobs:
       GO_MODULES: ${{ needs.changes.outputs.go_modules }}
       PACKS: ${{ needs.packs.result }}
       SELECT_PACKS: ${{ needs.changes.outputs.packs }}
+      PACK_TOOLS: ${{ needs.pack-tools.result }}
       PACK_BEHAVIOR: ${{ needs.pack-behavior.result }}
       SELECT_PACK_BEHAVIOR: ${{ needs.changes.outputs.pack_behavior }}
       SIGNING_E2E: ${{ needs.signing-e2e.result }}
@@ -838,8 +899,10 @@ jobs:
           fi
           require_selected PACKS "$SELECT_PACKS"
           if [ "$SELECT_PACK_BEHAVIOR" = '[]' ]; then
+            require_selected PACK_TOOLS false
             require_selected PACK_BEHAVIOR false
           else
+            require_selected PACK_TOOLS true
             require_selected PACK_BEHAVIOR true
           fi
           require_selected SIGNING_E2E "$SELECT_SIGNING_E2E"

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -131,6 +131,14 @@ jobs:
           tags: ${{ steps.tools.outputs.image }}
           cache-from: type=gha,scope=packtest-tools
 
+      # setup-buildx-action leaves its container-driver builder selected for the
+      # rest of the job, and that builder has its own image store. A pack whose
+      # client image starts FROM the shared one would resolve that base against
+      # the registry and fail; the daemon is where the restore just loaded it.
+      - name: Build against the daemon's image store
+        if: steps.tools.outputs.image != ''
+        run: docker buildx use default
+
       - name: Exercise pack behavior
         run: ./run test packs "$PACK" --shard "$SHARD"
 

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -36,6 +36,23 @@ jobs:
         name: Discover committed compatibility rows
         run: echo "matrix=$(go run ./tools/cmd/packtest --matrix --packs ./packs)" >> "$GITHUB_OUTPUT"
 
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # One writer for the whole matrix; the rows below only restore.
+      - name: Populate the shared client image cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
+          cache-to: type=gha,mode=min,scope=packtest-tools
+
   behavior:
     name: ${{ matrix.pack }} ${{ matrix.version }}
     needs: plans
@@ -65,6 +82,25 @@ jobs:
           cache-dependency-path: |
             runner/go.sum
             tools/go.sum
+
+      # Empty for a pack that ships its own client image, which then needs
+      # neither the builder nor the restore.
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image "$PACK")" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.tools.outputs.image != ''
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Restore the shared client image
+        if: steps.tools.outputs.image != ''
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
 
       - name: Exercise pack behavior
         run: ./run test packs "$PACK"

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -72,7 +72,7 @@ jobs:
           cache-to: type=gha,mode=min,scope=packtest-tools
 
   behavior:
-    name: ${{ matrix.pack }} ${{ matrix.version }}
+    name: ${{ matrix.pack }} ${{ matrix.version }}${{ matrix.shards > 1 && format(' shard {0}/{1}', matrix.shard, matrix.shards) || '' }}
     needs: plans
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -86,6 +86,7 @@ jobs:
       PACK: ${{ matrix.pack }}
       PACKTEST_VERSION: ${{ matrix.version }}
       PACKTEST_DIGEST: ${{ matrix.digest }}
+      SHARD: ${{ matrix.shard }}/${{ matrix.shards }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -128,13 +129,13 @@ jobs:
           cache-from: type=gha,scope=packtest-tools
 
       - name: Exercise pack behavior
-        run: ./run test packs "$PACK"
+        run: ./run test packs "$PACK" --shard "$SHARD"
 
       - name: Upload failed pack report
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: pack-behavior-${{ matrix.pack }}-${{ matrix.version }}
+          name: pack-behavior-${{ matrix.pack }}-${{ matrix.version }}-${{ matrix.shard }}
           path: dev/test-packs/reports
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -28,13 +28,31 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: tools/go.mod
-          cache: true
-          cache-dependency-path: tools/go.*
+          go-version-file: runner/go.mod
+          cache: false
+
+      # setup-go's cache is keyed on go.sum alone and shared with every other
+      # Go job, so whichever saves it first decides which build flags the
+      # restored objects carry. The behavior rows want these ones.
+      - name: Cache the behavior build objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
 
       - id: discover
         name: Discover committed compatibility rows
         run: echo "matrix=$(go run ./tools/cmd/packtest --matrix --packs ./packs)" >> "$GITHUB_OUTPUT"
+
+      - name: Warm the behavior build objects
+        env:
+          GOOS: linux
+          CGO_ENABLED: "0"
+        run: |
+          go -C runner build -trimpath -o /dev/null .
+          go -C tools build -trimpath -o /dev/null ./cmd/packtest
 
       - id: tools
         name: Resolve the shared client image
@@ -78,10 +96,17 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: runner/go.mod
-          cache: true
-          cache-dependency-path: |
-            runner/go.sum
-            tools/go.sum
+          cache: false
+
+      # Read-only: plans wrote this entry with the flags packTest's preflight
+      # cross-compiles under, so the rows link rather than rebuild.
+      - name: Restore the behavior build objects
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
 
       # Empty for a pack that ships its own client image, which then needs
       # neither the builder nor the restore.

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -78,7 +78,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      max-parallel: 4
+      # 57 rows of mostly-idle Docker waits. The cap was low to spare Docker
+      # Hub, which reusing the shared client image relieved: a row now pulls
+      # its own SUT rather than nine images it mostly never runs.
+      max-parallel: 12
       matrix:
         include: ${{ fromJSON(needs.plans.outputs.matrix) }}
     env:

--- a/dev/test-packs/README.md
+++ b/dev/test-packs/README.md
@@ -31,8 +31,10 @@ dev/test-packs/
 ```
 
 Every case gets its own Compose project, network, volumes, SUT lifecycle, and
-runner-tools container. The devtool builds shared and pack-specific images once,
-then runs up to four isolated cases concurrently. Arrange steps can create the
+runner-tools container. The devtool builds pack-specific images once, reuses the
+shared client image whenever its tag is already present, and skips that image
+entirely for a pack that ships its own client. It then runs up to four isolated
+cases concurrently. Arrange steps can create the
 exact prerequisite state for a case. Terminal actions can stop or destroy their
 fixture without affecting any later case.
 
@@ -188,7 +190,9 @@ dev/test-packs/reports/<invocation>/<pack>/<case>.log
 Each command prints its invocation-specific report directory. That same
 invocation identity isolates its Compose projects, so separate commands may
 exercise the same pack and case concurrently without sharing containers,
-volumes, networks, runner-tools image tags, or report files.
+volumes, networks, or report files. The shared client image is the deliberate
+exception: it is tagged by the bytes of its Dockerfile, so every run and every
+checkout reuses one build and changed content lands on a new tag.
 
 Each case report records the pack and SUT versions, image digest, execution
 identity, resolved images, action result, and durations. Failures also capture

--- a/packs/apache-httpd/test/compose.yaml
+++ b/packs/apache-httpd/test/compose.yaml
@@ -24,6 +24,8 @@ services:
     healthcheck:
       test: ["CMD", "httpd", "-t"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 20
 
 volumes:

--- a/packs/bind/test/compose.yaml
+++ b/packs/bind/test/compose.yaml
@@ -26,6 +26,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "rndc status >/dev/null"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 30
 
 volumes:

--- a/packs/caddy/test/compose.yaml
+++ b/packs/caddy/test/compose.yaml
@@ -25,6 +25,8 @@ services:
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 20
 
 volumes:

--- a/packs/cassandra/test/cases.yaml
+++ b/packs/cassandra/test/cases.yaml
@@ -10,6 +10,11 @@ versions:
     default: true
   - version: "4.1.8"
     digest: "@sha256:8b774810a1a6cf1c5974c4a719b84b3f9096d5d12e923c56e3f8031a942e8bf9"
+# A JVM node takes about a minute to gossip and answer cqlsh, and every case
+# pays that boot for its own SUT. Split the cases across matrix rows instead of
+# sharing a node between them.
+shards: 4
+
 secret_env: [CQLSH_PASSWORD]
 env:
   CQLSH_HOST: 127.0.0.1

--- a/packs/cassandra/test/compose.yaml
+++ b/packs/cassandra/test/compose.yaml
@@ -45,6 +45,8 @@ services:
           CREATE TABLE IF NOT EXISTS packtest.events (id int PRIMARY KEY, value text);
           INSERT INTO packtest.events (id, value) VALUES (1, 'ready');" >/dev/null && exit 1))
       interval: 10s
+      start_period: 120s
+      start_interval: 2s
       timeout: 10s
       retries: 30
     volumes:

--- a/packs/clickhouse/test/compose.yaml
+++ b/packs/clickhouse/test/compose.yaml
@@ -15,4 +15,6 @@ services:
       # handoff to the final server.
       test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' >/dev/null && sleep 2 && clickhouse-client --query 'SELECT 1' >/dev/null"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/cockroach/test/cases.yaml
+++ b/packs/cockroach/test/cases.yaml
@@ -56,6 +56,13 @@ cases:
   - action: cockroach.table_row_counts
     arrange:
       - argv: [cockroach, sql, --url, "postgresql://root@cockroach:26257/defaultdb?sslmode=disable", -e, "CREATE TABLE IF NOT EXISTS packtest_rows (id INT PRIMARY KEY); UPSERT INTO packtest_rows VALUES (1), (2), (3); ANALYZE packtest_rows"]
+      # ANALYZE returns before the statistic it wrote is readable, and the
+      # action reads the statistic rather than the table.
+      - argv: [cockroach, sql, --url, "postgresql://root@cockroach:26257/defaultdb?sslmode=disable", --format=tsv, -e, "SET allow_unsafe_internals = true; SELECT table_name FROM crdb_internal.table_row_statistics WHERE table_name = 'packtest_rows'"]
+        retry_for: 30s
+        retry_every: 500ms
+        expect:
+          stdout_contains: [packtest_rows]
     expect:
       stdout_contains: [table_name, packtest_rows]
     cleanup:

--- a/packs/cockroach/test/compose.yaml
+++ b/packs/cockroach/test/compose.yaml
@@ -5,4 +5,6 @@ services:
     healthcheck:
       test: ["CMD", "cockroach", "sql", "--insecure", "-e", "SELECT 1"]
       interval: 10s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/consul/test/compose.yaml
+++ b/packs/consul/test/compose.yaml
@@ -5,4 +5,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8500/v1/agent/metrics | grep -q '\"Timestamp\"'"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 30

--- a/packs/elasticsearch/test/compose.yaml
+++ b/packs/elasticsearch/test/compose.yaml
@@ -16,4 +16,6 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-fsSL", "http://localhost:9200/_cluster/health"]
       interval: 10s
+      start_period: 120s
+      start_interval: 1s
       retries: 20

--- a/packs/grafana/test/compose.yaml
+++ b/packs/grafana/test/compose.yaml
@@ -7,4 +7,6 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/api/health"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 30

--- a/packs/haproxy/test/compose.yaml
+++ b/packs/haproxy/test/compose.yaml
@@ -18,6 +18,8 @@ services:
     healthcheck:
       test: ["CMD", "test", "-S", "/run/haproxy/admin.sock"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 20
 
 volumes:

--- a/packs/kafka/test/compose.yaml
+++ b/packs/kafka/test/compose.yaml
@@ -28,5 +28,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --create --if-not-exists --topic orders --partitions 2 --replication-factor 1 >/dev/null && /opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list | grep -q orders"]
       interval: 5s
+      start_period: 90s
+      start_interval: 2s
       timeout: 10s
       retries: 30

--- a/packs/kubernetes/test/cases.yaml
+++ b/packs/kubernetes/test/cases.yaml
@@ -8,6 +8,11 @@ versions:
     default: true
   - version: v1.34.6-k3s1
     digest: "@sha256:73beaf51eaf1ab553d11aedd55ffdb5800d4e7e694f43dea6ca24aa87ff79fcb"
+# A single-node k3s server plus its probe pod takes about a minute to reach
+# Ready, and every case pays that boot for its own cluster. Split the cases
+# across matrix rows instead of sharing a cluster between them.
+shards: 5
+
 env:
   KUBECONFIG: /shared/kubeconfig.yaml
 defaults:

--- a/packs/kubernetes/test/compose.yaml
+++ b/packs/kubernetes/test/compose.yaml
@@ -16,6 +16,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "kubectl get nodes | grep -q ' Ready' && kubectl wait --for=condition=Ready pod/probe --timeout=2s >/dev/null && kubectl get crd harnesses.packtest.emisar.dev >/dev/null"]
       interval: 10s
+      start_period: 120s
+      start_interval: 1s
       retries: 30
 
   k3s-kubeconfig:
@@ -27,6 +29,8 @@ services:
     healthcheck:
       test: ["CMD", "test", "-f", "/shared/ready"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 20
 
 volumes:

--- a/packs/memcached/test/compose.yaml
+++ b/packs/memcached/test/compose.yaml
@@ -5,4 +5,6 @@ services:
     healthcheck:
       test: ["CMD", "pidof", "memcached"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/minio/test/compose.yaml
+++ b/packs/minio/test/compose.yaml
@@ -8,4 +8,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -fsSL http://localhost:9000/minio/health/live"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/mongodb/test/compose.yaml
+++ b/packs/mongodb/test/compose.yaml
@@ -7,6 +7,12 @@ services:
     volumes:
       - ${EMISAR_ROOT}/packs/mongodb/test/fixtures/init.js:/docker-entrypoint-initdb.d/init.js:ro
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      # Dial the routable address, never loopback. The entrypoint seeds through
+      # a temporary mongod bound to 127.0.0.1 and shuts it down before the real
+      # one starts, so a loopback ping reports healthy while a case connecting
+      # over the network still gets ECONNREFUSED.
+      test: ["CMD-SHELL", "mongosh --host \"$$(hostname -i)\" --quiet --eval \"db.adminCommand('ping').ok\""]
       interval: 10s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/mysql/test/compose.yaml
+++ b/packs/mysql/test/compose.yaml
@@ -9,4 +9,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "mysql -h 127.0.0.1 -uroot -ppacktest-canary-mysql-root-b813 -Nse 'SELECT COUNT(*) FROM testdb.orders' >/dev/null"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 30

--- a/packs/nginx/test/compose.yaml
+++ b/packs/nginx/test/compose.yaml
@@ -27,6 +27,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1/nginx_status | grep -q 'Active connections'"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 20
 
 volumes:

--- a/packs/nomad/test/compose.yaml
+++ b/packs/nomad/test/compose.yaml
@@ -6,4 +6,6 @@ services:
     healthcheck:
       test: ["CMD", "nomad", "server", "members"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/postfix/test/compose.yaml
+++ b/packs/postfix/test/compose.yaml
@@ -24,6 +24,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "postfix status >/dev/null && postconf -h myhostname | grep -q postfix.example.test"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 30
 
 volumes:

--- a/packs/postgres/test/compose.yaml
+++ b/packs/postgres/test/compose.yaml
@@ -7,6 +7,11 @@ services:
     volumes:
       - ${EMISAR_ROOT}/packs/postgres/test/fixtures/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      # Dial the routable address, never the socket. The entrypoint seeds
+      # through a temporary postmaster with listen_addresses empty, which
+      # answers on the socket while a case connecting over the network cannot.
+      test: ["CMD-SHELL", "pg_isready -h \"$$(hostname -i)\" -U postgres"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/prometheus/test/compose.yaml
+++ b/packs/prometheus/test/compose.yaml
@@ -10,4 +10,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- 'http://localhost:9090/api/v1/query?query=up' | grep -q '\"job\":\"prometheus\"'"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 30

--- a/packs/rabbitmq/test/compose.yaml
+++ b/packs/rabbitmq/test/compose.yaml
@@ -23,4 +23,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "rabbitmq-diagnostics -q check_running && rabbitmqadmin -u guest -p guest declare queue --name packtest --durable true --non-interactive >/dev/null"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 30

--- a/packs/rabbitmq/test/compose.yaml
+++ b/packs/rabbitmq/test/compose.yaml
@@ -23,6 +23,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "rabbitmq-diagnostics -q check_running && rabbitmqadmin -u guest -p guest declare queue --name packtest --durable true --non-interactive >/dev/null"]
       interval: 5s
+      # No start_interval: this check is an Erlang client, and probing before
+      # the entrypoint has finished writing /var/lib/rabbitmq/.erlang.cookie
+      # leaves the file unreadable by the server the entrypoint then starts.
       start_period: 30s
-      start_interval: 1s
       retries: 30

--- a/packs/redis/test/compose.yaml
+++ b/packs/redis/test/compose.yaml
@@ -13,4 +13,6 @@ services:
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/snmp/test/compose.yaml
+++ b/packs/snmp/test/compose.yaml
@@ -14,6 +14,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "snmpget -v2c -c packtest-canary-snmp-community-b410 -On 127.0.0.1 1.3.6.1.2.1.1.5.0 >/dev/null 2>&1"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       timeout: 3s
       retries: 30
 
@@ -37,4 +39,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "MIBS='' snmpbulkwalk -v2c -c packtest-canary-snmp-community-b410 -On 127.0.0.1 1.3.6.1.2.1.14.10 2>/dev/null | grep -q 192.168.99.2"]
       interval: 2s
+      start_period: 30s
+      start_interval: 1s
       retries: 30

--- a/packs/typesense/test/compose.yaml
+++ b/packs/typesense/test/compose.yaml
@@ -7,6 +7,8 @@ services:
     healthcheck:
       test: ["CMD", "/usr/bin/bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/8108; printf 'GET /health HTTP/1.0\\r\\n\\r\\n' >&3; grep -q '\"ok\":true' <&3"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 20
 
 volumes:

--- a/packs/vault/test/compose.yaml
+++ b/packs/vault/test/compose.yaml
@@ -9,4 +9,6 @@ services:
     healthcheck:
       test: ["CMD", "vault", "status"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/packs/zookeeper/test/compose.yaml
+++ b/packs/zookeeper/test/compose.yaml
@@ -6,7 +6,10 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep -q imok"]
+      # Every case reaches 2181 over the bridge, so readiness has to prove
+      # that path: loopback answers ruok while a bridge connection still
+      # gets closed empty, and faster readiness starts cases in that gap.
+      test: ["CMD-SHELL", "echo ruok | nc -w 2 \"$$(hostname -i)\" 2181 | grep -q imok"]
       interval: 5s
       start_period: 30s
       start_interval: 1s

--- a/packs/zookeeper/test/compose.yaml
+++ b/packs/zookeeper/test/compose.yaml
@@ -8,4 +8,6 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 5s
+      start_period: 30s
+      start_interval: 1s
       retries: 10

--- a/tools/internal/devtool/devtool_test.go
+++ b/tools/internal/devtool/devtool_test.go
@@ -266,8 +266,9 @@ func TestPackTestComposeProjectIsInvocationAndCaseSpecific(t *testing.T) {
 
 func TestPackTestComposeEnvUsesCaseIdentity(t *testing.T) {
 	plan := packtest.PlanRef{Name: "postfix"}
-	nonroot := packTestComposeEnv("/tmp/repo", "run-1", plan, "read", nil, "")
-	root := packTestComposeEnv("/tmp/repo", "run-1", plan, "reload", nil, "root")
+	image := "emisar-runner-tools:abc123456789"
+	nonroot := packTestComposeEnv("/tmp/repo", "run-1", image, plan, "read", nil, "")
+	root := packTestComposeEnv("/tmp/repo", "run-1", image, plan, "reload", nil, "root")
 	if nonroot["PACKTEST_RUNNER_USER"] != "65532:65532" {
 		t.Fatalf("non-root identity = %q", nonroot["PACKTEST_RUNNER_USER"])
 	}
@@ -277,7 +278,7 @@ func TestPackTestComposeEnvUsesCaseIdentity(t *testing.T) {
 	if nonroot["COMPOSE_PROJECT_NAME"] == root["COMPOSE_PROJECT_NAME"] {
 		t.Fatal("case-specific projects collided")
 	}
-	if nonroot["PACKTEST_RUNNER_IMAGE"] != packTestRunnerImage("/tmp/repo", "run-1") {
+	if nonroot["PACKTEST_RUNNER_IMAGE"] != "emisar-runner-tools:abc123456789" {
 		t.Fatalf("runner image = %q", nonroot["PACKTEST_RUNNER_IMAGE"])
 	}
 }
@@ -289,11 +290,32 @@ func TestPackTestInvocationIDIncludesProcessAndNanoseconds(t *testing.T) {
 	}
 }
 
-func TestPackTestRunnerImageIsInvocationSpecific(t *testing.T) {
-	first := packTestRunnerImage("/tmp/repo", "run-1")
-	if first == packTestRunnerImage("/tmp/repo", "run-2") ||
-		first == packTestRunnerImage("/tmp/other", "run-1") {
-		t.Fatalf("runner image is not invocation-specific: %q", first)
+func TestPackTestRunnerImageTracksTheDockerfile(t *testing.T) {
+	write := func(dockerfile string) string {
+		t.Helper()
+		root := t.TempDir()
+		harness := filepath.Join(root, "dev", "test-packs")
+		if err := os.MkdirAll(harness, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(harness, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		image, err := packTestRunnerImage(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return image
+	}
+	original := write("FROM debian:13-slim\n")
+	if original != write("FROM debian:13-slim\n") {
+		t.Fatalf("same Dockerfile in two checkouts must share one image: %q", original)
+	}
+	if original == write("FROM debian:13-slim\nRUN apt-get update\n") {
+		t.Fatalf("changed Dockerfile must land on a new tag: %q", original)
+	}
+	if _, err := packTestRunnerImage(t.TempDir()); err == nil {
+		t.Fatal("a missing Dockerfile must be an error, not an empty tag")
 	}
 }
 

--- a/tools/internal/devtool/devtool_test.go
+++ b/tools/internal/devtool/devtool_test.go
@@ -297,6 +297,73 @@ func TestPackTestRunnerImageIsInvocationSpecific(t *testing.T) {
 	}
 }
 
+func TestPackTestNeedsSharedTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		compose string
+		want    bool
+	}{
+		{
+			name:    "inherits the shared service",
+			compose: "services:\n  fixture:\n    image: redis:8.8.0\n",
+			want:    true,
+		},
+		{
+			name:    "tweaks the shared service",
+			compose: "services:\n  runner-tools:\n    volumes: [data:/data]\n",
+			want:    true,
+		},
+		{
+			name: "derives from the shared image",
+			compose: "services:\n  runner-tools:\n    build:\n      context: .\n" +
+				"      args:\n        PACKTEST_RUNNER_IMAGE: ${PACKTEST_RUNNER_IMAGE:-emisar-runner-tools:latest}\n",
+			want: true,
+		},
+		{
+			name: "replaces the shared image",
+			compose: "services:\n  runner-tools:\n    build:\n      context: .\n" +
+				"      args:\n        PACKTEST_VERSION: ${PACKTEST_VERSION:-5.0.8}\n",
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "compose.yaml"), []byte(test.compose), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			plans := []packtest.PlanRef{{Name: "fixture", Path: filepath.Join(dir, "cases.yaml")}}
+			got, err := packTestNeedsSharedTools(plans)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("needs shared tools = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPackTestNeedsSharedToolsWhenAnyPlanReachesIt(t *testing.T) {
+	plan := func(compose string) packtest.PlanRef {
+		t.Helper()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "compose.yaml"), []byte(compose), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return packtest.PlanRef{Name: "fixture", Path: filepath.Join(dir, "cases.yaml")}
+	}
+	replaces := plan("services:\n  runner-tools:\n    build:\n      context: .\n      args:\n        PACKTEST_VERSION: x\n")
+	inherits := plan("services:\n  fixture:\n    image: redis:8.8.0\n")
+	got, err := packTestNeedsSharedTools([]packtest.PlanRef{replaces, inherits})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("a selection containing an inheriting plan must build the shared image")
+	}
+}
+
 func TestSelectPackTestCaseRequiresOneExactCase(t *testing.T) {
 	plans := []packtest.PlanRef{{
 		Name: "postgres",

--- a/tools/internal/devtool/devtool_test.go
+++ b/tools/internal/devtool/devtool_test.go
@@ -386,6 +386,45 @@ func TestPackTestNeedsSharedToolsWhenAnyPlanReachesIt(t *testing.T) {
 	}
 }
 
+func TestSelectPackTestShard(t *testing.T) {
+	plans := []packtest.PlanRef{{
+		Name:   "cassandra",
+		Shards: 2,
+		Cases: []packtest.CaseRef{
+			{ID: "cassandra.status"}, {ID: "cassandra.info"},
+			{ID: "cassandra.ring"}, {ID: "cassandra.version"},
+		},
+	}}
+	selected, err := selectPackTestShard(plans, "2/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(selected) != 1 || len(selected[0].Cases) != 2 ||
+		selected[0].Cases[0].ID != "cassandra.info" || selected[0].Cases[1].ID != "cassandra.version" {
+		t.Fatalf("selected = %+v", selected[0].Cases)
+	}
+	if unsharded, err := selectPackTestShard(plans, ""); err != nil || len(unsharded[0].Cases) != 4 {
+		t.Fatalf("no shard selector must keep every case: %+v %v", unsharded, err)
+	}
+	for _, test := range []struct{ shard, want string }{
+		{"3/2", "outside 1..2"},
+		{"0/2", "outside 1..2"},
+		{"1/3", "declares 2 shards"},
+		{"1", "<index>/<count>"},
+		{"a/2", "is not a number"},
+		{"1/b", "is not a number"},
+	} {
+		if _, err := selectPackTestShard(plans, test.shard); err == nil ||
+			!strings.Contains(err.Error(), test.want) {
+			t.Fatalf("shard %q error = %v, want %q", test.shard, err, test.want)
+		}
+	}
+	if _, err := selectPackTestShard(append(plans, plans[0]), "1/2"); err == nil ||
+		!strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("ambiguous pack error = %v", err)
+	}
+}
+
 func TestSelectPackTestCaseRequiresOneExactCase(t *testing.T) {
 	plans := []packtest.PlanRef{{
 		Name: "postgres",

--- a/tools/internal/devtool/gates.go
+++ b/tools/internal/devtool/gates.go
@@ -41,6 +41,8 @@ const (
   tools [go-test-args...]    run all tooling tests, or pass focused go test arguments
   packs [name-pattern]       run pack behavior plans against real services
   packs <name> --case <id>   run one isolated behavior case
+  packs <name> --shard <i>/<n>
+                             run one declared shard of a slow pack's cases
   packs --names a,b          run an exact set of pack behavior plans
   install <runner|mcp>       exercise a public installer in an isolated harness
 `
@@ -123,19 +125,22 @@ func (a *App) test(ctx context.Context, args []string) error {
 					return usage("usage: ./run test packs --names pack-a,pack-b")
 				}
 			}
-			return a.packTest(ctx, "", names, "")
+			return a.packTest(ctx, "", names, "", "")
 		}
 		if len(rest) == 3 && rest[1] == "--case" && rest[0] != "" && rest[2] != "" {
-			return a.packTest(ctx, rest[0], nil, rest[2])
+			return a.packTest(ctx, rest[0], nil, rest[2], "")
+		}
+		if len(rest) == 3 && rest[1] == "--shard" && rest[0] != "" && rest[2] != "" {
+			return a.packTest(ctx, rest[0], nil, "", rest[2])
 		}
 		if len(rest) > 1 {
-			return usage("usage: ./run test packs [name-pattern] | ./run test packs <name> --case <id> | ./run test packs --names pack-a,pack-b")
+			return usage("usage: ./run test packs [name-pattern] | ./run test packs <name> --case <id> | ./run test packs <name> --shard <i>/<n> | ./run test packs --names pack-a,pack-b")
 		}
 		pattern := ""
 		if len(rest) == 1 {
 			pattern = rest[0]
 		}
-		return a.packTest(ctx, pattern, nil, "")
+		return a.packTest(ctx, pattern, nil, "", "")
 	case "install":
 		if len(rest) != 1 || rest[0] != "runner" && rest[0] != "mcp" {
 			return usage("usage: ./run test install <runner|mcp>")

--- a/tools/internal/devtool/gates.go
+++ b/tools/internal/devtool/gates.go
@@ -61,6 +61,8 @@ const (
   check <name>               validate one pack without changing artifacts
   hashes [--write]           verify or refresh cross-language pack hash goldens
   sync <name> --fix          rebuild the catalog from the live registry history
+  tools-image [<name>]       print the shared behavior client image tag, or
+                             nothing when the named pack ships its own client
 
 Use "./run test packs [name-pattern]" for pack-owned behavior cases and
 "./run gate packs" for the complete pack Definition of Done.

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -99,11 +99,11 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 	}
 	bin := filepath.Join(harness, "bin")
 	baseCompose := filepath.Join(harness, "compose.yaml")
-	runnerImage := packTestRunnerImage(a.Root, invocationID)
+	runnerImage, runnerImageErr := packTestRunnerImage(a.Root)
 	sharedTools, sharedToolsErr := packTestNeedsSharedTools(plans)
 	preflightErr := func() error {
-		if sharedToolsErr != nil {
-			return sharedToolsErr
+		if err := errors.Join(runnerImageErr, sharedToolsErr); err != nil {
+			return err
 		}
 		if err := os.MkdirAll(bin, 0o755); err != nil {
 			return err
@@ -115,7 +115,7 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 		if err := a.run(ctx, filepath.Join(a.Root, "tools"), env, "go", "build", "-trimpath", "-o", filepath.Join(bin, "packtest"), "./cmd/packtest"); err != nil {
 			return err
 		}
-		if !sharedTools {
+		if !sharedTools || a.hasImage(ctx, runnerImage) {
 			return nil
 		}
 		composeEnv := map[string]string{
@@ -127,15 +127,12 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 	if preflightErr != nil {
 		return errors.Join(preflightErr, writePackTestFailureReports(reports, plans, requestedVersionEnv, preflightErr))
 	}
-	if sharedTools {
-		defer a.removePackTestRunnerImage(runnerImage)
-	}
 
 	versionEnvs := make(map[string]map[string]string, len(plans))
 	for _, plan := range plans {
 		versionEnv := resolvedPackTestVersionEnv(plan, requestedVersionEnv)
 		versionEnvs[plan.Name] = versionEnv
-		if err := a.preparePackTestPlan(ctx, baseCompose, invocationID, plan, versionEnv); err != nil {
+		if err := a.preparePackTestPlan(ctx, baseCompose, invocationID, runnerImage, plan, versionEnv); err != nil {
 			return errors.Join(err, writePackTestFailureReports(reports, []packtest.PlanRef{plan}, requestedVersionEnv, err))
 		}
 	}
@@ -169,7 +166,7 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 				writePackTestReportHeader(&output, job.Plan, job.Case.ID, job.VersionEnv, job.Case.RunnerUser)
 				worker := New(a.Root, nil, &output, &output)
 				started := time.Now()
-				runErr := worker.runPackTestCase(ctx, baseCompose, job)
+				runErr := worker.runPackTestCase(ctx, baseCompose, runnerImage, job)
 				duration := time.Since(started).Round(time.Millisecond)
 				fmt.Fprintf(&output, "\nCase duration: %s\n", duration)
 				if runErr != nil {
@@ -311,6 +308,7 @@ func (a *App) preparePackTestPlan(
 	ctx context.Context,
 	baseCompose string,
 	invocationID string,
+	runnerImage string,
 	plan packtest.PlanRef,
 	versionEnv map[string]string,
 ) error {
@@ -326,7 +324,7 @@ func (a *App) preparePackTestPlan(
 		return err
 	}
 	compose := []string{"compose", "-f", baseCompose, "-f", packCompose}
-	env := packTestComposeEnv(a.Root, invocationID, plan, "build", versionEnv, plan.Runner.User)
+	env := packTestComposeEnv(a.Root, invocationID, runnerImage, plan, "build", versionEnv, plan.Runner.User)
 
 	output, err := a.output(ctx, a.Root, env, "docker", append(compose, "config", "--services")...)
 	if err != nil {
@@ -359,12 +357,13 @@ func (a *App) preparePackTestPlan(
 	return nil
 }
 
-func (a *App) runPackTestCase(ctx context.Context, baseCompose string, job packTestJob) error {
+func (a *App) runPackTestCase(ctx context.Context, baseCompose, runnerImage string, job packTestJob) error {
 	packCompose := filepath.Join(filepath.Dir(job.Plan.Path), "compose.yaml")
 	compose := []string{"compose", "-f", baseCompose, "-f", packCompose}
 	env := packTestComposeEnv(
 		a.Root,
 		job.InvocationID,
+		runnerImage,
 		job.Plan,
 		job.Case.ID,
 		job.VersionEnv,
@@ -466,6 +465,7 @@ func packTestBuildServices(path string) ([]string, error) {
 func packTestComposeEnv(
 	root string,
 	invocationID string,
+	runnerImage string,
 	plan packtest.PlanRef,
 	caseID string,
 	versionEnv map[string]string,
@@ -481,7 +481,7 @@ func packTestComposeEnv(
 	env := map[string]string{
 		"COMPOSE_PROJECT_NAME":  packTestComposeProject(root, invocationID, plan.Name, caseID),
 		"EMISAR_ROOT":           root,
-		"PACKTEST_RUNNER_IMAGE": packTestRunnerImage(root, invocationID),
+		"PACKTEST_RUNNER_IMAGE": runnerImage,
 		"PACKTEST_RUNNER_USER":  composeUser,
 	}
 	for key, value := range versionEnv {
@@ -616,9 +616,18 @@ func packTestInvocationID(now time.Time, pid int) string {
 	return fmt.Sprintf("%s-%d", now.UTC().Format("20060102T150405.000000000Z"), pid)
 }
 
-func packTestRunnerImage(root, invocationID string) string {
-	hash := fmt.Sprintf("%x", sha256sum(root+"\x00"+invocationID))
-	return "emisar-runner-tools:" + hash[:12]
+// packTestRunnerImage names the shared client image after the bytes that
+// produce it. The Dockerfile COPYs nothing from its build context, so those
+// bytes are the entire input: a run that already has the tag can reuse a ~2GB
+// image instead of pulling eight servers to extract one binary from each, and
+// changed content lands on a different tag rather than staling this one.
+func packTestRunnerImage(root string) (string, error) {
+	dockerfile, err := os.ReadFile(filepath.Join(root, "dev", "test-packs", "Dockerfile"))
+	if err != nil {
+		return "", err
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256(dockerfile))
+	return "emisar-runner-tools:" + hash[:12], nil
 }
 
 func packTestComposeProject(root, invocationID, pack, caseID string) string {
@@ -635,12 +644,9 @@ func packTestComposeProject(root, invocationID, pack, caseID string) string {
 	return "emisar-packtest-" + name + "-" + hash[:12]
 }
 
-func (a *App) removePackTestRunnerImage(image string) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	if _, err := a.output(ctx, a.Root, nil, "docker", "image", "rm", image); err != nil {
-		fmt.Fprintf(a.Err, "warning: remove pack-test image %s: %v\n", image, err)
-	}
+func (a *App) hasImage(ctx context.Context, image string) bool {
+	_, err := a.output(ctx, a.Root, nil, "docker", "image", "inspect", image)
+	return err == nil
 }
 
 func (a *App) pack(ctx context.Context, args []string) error {
@@ -648,6 +654,34 @@ func (a *App) pack(ctx context.Context, args []string) error {
 		return usage("%s", packUsage)
 	}
 	action := args[0]
+	if action == "tools-image" {
+		if len(args) > 2 {
+			return usage("usage: ./run pack tools-image [<pack-name>]")
+		}
+		image, err := packTestRunnerImage(a.Root)
+		if err != nil {
+			return err
+		}
+		if len(args) == 2 {
+			// Named, the question is whether this pack reaches the image at
+			// all: a pack that ships its own client wants no part of it, and
+			// printing nothing is what lets CI skip restoring 2GB it will not
+			// run.
+			plans, err := packtest.Discover(filepath.Join(a.Root, "packs"), "", args[1])
+			if err != nil {
+				return err
+			}
+			needed, err := packTestNeedsSharedTools(plans)
+			if err != nil {
+				return err
+			}
+			if !needed {
+				return nil
+			}
+		}
+		fmt.Fprintln(a.Out, image)
+		return nil
+	}
 	if action == "hashes" {
 		if len(args) > 2 || len(args) == 2 && args[1] != "--write" {
 			return usage("usage: ./run pack hashes [--write]")

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -74,9 +75,13 @@ func (a *App) packSync(ctx context.Context, name string) error {
 	return a.run(ctx, filepath.Join(a.Portal, "apps", "emisar_web"), nil, "mix", "test", "test/emisar_web/packs_registry/cache_test.exs", "test/emisar_web/packs_test.exs")
 }
 
-func (a *App) packTest(ctx context.Context, pattern string, names []string, caseID string) error {
+func (a *App) packTest(ctx context.Context, pattern string, names []string, caseID, shard string) error {
 	harness := filepath.Join(a.Root, "dev", "test-packs")
 	plans, err := packtest.Discover(filepath.Join(a.Root, "packs"), pattern, names...)
+	if err != nil {
+		return err
+	}
+	plans, err = selectPackTestShard(plans, shard)
 	if err != nil {
 		return err
 	}
@@ -243,6 +248,41 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 		}
 	}
 	return errors.Join(failures...)
+}
+
+// selectPackTestShard keeps one slice of a single pack's cases. A pack whose
+// SUT boots slowly costs its case count times that boot, so splitting it across
+// matrix rows is what shortens the row without weakening the per-case isolation
+// that makes the boot unavoidable.
+func selectPackTestShard(plans []packtest.PlanRef, shard string) ([]packtest.PlanRef, error) {
+	if shard == "" {
+		return plans, nil
+	}
+	if len(plans) != 1 {
+		return nil, fmt.Errorf("--shard requires a name that selects exactly one pack")
+	}
+	index, count, ok := strings.Cut(shard, "/")
+	if !ok {
+		return nil, fmt.Errorf("--shard takes <index>/<count>, not %q", shard)
+	}
+	selected, err := strconv.Atoi(index)
+	if err != nil {
+		return nil, fmt.Errorf("--shard index %q is not a number", index)
+	}
+	total, err := strconv.Atoi(count)
+	if err != nil {
+		return nil, fmt.Errorf("--shard count %q is not a number", count)
+	}
+	plan := plans[0]
+	declared := max(plan.Shards, 1)
+	if total != declared {
+		return nil, fmt.Errorf("pack %s declares %d shards, not %d", plan.Name, declared, total)
+	}
+	if selected < 1 || selected > total {
+		return nil, fmt.Errorf("--shard index %d is outside 1..%d", selected, total)
+	}
+	plan.Cases = packtest.SelectShard(plan.Cases, selected, total)
+	return []packtest.PlanRef{plan}, nil
 }
 
 func selectPackTestCase(plans []packtest.PlanRef, caseID string) ([]packtest.PlanRef, error) {

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -129,12 +129,15 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 	}
 
 	versionEnvs := make(map[string]map[string]string, len(plans))
+	images := make(map[string]string, len(plans))
 	for _, plan := range plans {
 		versionEnv := resolvedPackTestVersionEnv(plan, requestedVersionEnv)
 		versionEnvs[plan.Name] = versionEnv
-		if err := a.preparePackTestPlan(ctx, baseCompose, invocationID, runnerImage, plan, versionEnv); err != nil {
+		resolved, err := a.preparePackTestPlan(ctx, baseCompose, invocationID, runnerImage, plan, versionEnv)
+		if err != nil {
 			return errors.Join(err, writePackTestFailureReports(reports, []packtest.PlanRef{plan}, requestedVersionEnv, err))
 		}
+		images[plan.Name] = resolved
 	}
 
 	var queued []packTestJob
@@ -145,6 +148,7 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 				Plan:         plan,
 				Case:         test,
 				VersionEnv:   versionEnvs[plan.Name],
+				Images:       images[plan.Name],
 			})
 		}
 	}
@@ -294,6 +298,7 @@ type packTestJob struct {
 	Plan         packtest.PlanRef
 	Case         packtest.CaseRef
 	VersionEnv   map[string]string
+	Images       string
 }
 
 type packTestCaseResult struct {
@@ -311,50 +316,58 @@ func (a *App) preparePackTestPlan(
 	runnerImage string,
 	plan packtest.PlanRef,
 	versionEnv map[string]string,
-) error {
+) (string, error) {
 	packCompose := filepath.Join(filepath.Dir(plan.Path), "compose.yaml")
 	if !isFile(packCompose) {
-		return fmt.Errorf("behavior plan has no sibling compose.yaml")
+		return "", fmt.Errorf("behavior plan has no sibling compose.yaml")
 	}
 	if len(plan.Services) == 0 {
-		return fmt.Errorf("behavior plan has no primary SUT service")
+		return "", fmt.Errorf("behavior plan has no primary SUT service")
 	}
 	defaultVersion := plan.DefaultVersion()
 	if err := validatePackTestVersionInput(packCompose, plan.Services[0], defaultVersion.Version); err != nil {
-		return err
+		return "", err
 	}
 	compose := []string{"compose", "-f", baseCompose, "-f", packCompose}
 	env := packTestComposeEnv(a.Root, invocationID, runnerImage, plan, "build", versionEnv, plan.Runner.User)
 
 	output, err := a.output(ctx, a.Root, env, "docker", append(compose, "config", "--services")...)
 	if err != nil {
-		return err
+		return "", err
 	}
 	available := make(map[string]bool)
 	for _, service := range strings.Fields(string(output)) {
 		available[service] = true
 	}
 	if !available["runner-tools"] {
-		return fmt.Errorf("the Compose project has no runner-tools service")
+		return "", fmt.Errorf("the Compose project has no runner-tools service")
 	}
 	for _, service := range plan.Services {
 		if !available[service] {
-			return fmt.Errorf("requires unknown Compose service %s", service)
+			return "", fmt.Errorf("requires unknown Compose service %s", service)
 		}
 	}
 
 	buildServices, err := packTestBuildServices(packCompose)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if len(buildServices) > 0 {
 		buildArgs := append(append([]string{}, compose...), "build")
 		buildArgs = append(buildArgs, buildServices...)
 		if err := a.run(ctx, a.Root, env, "docker", buildArgs...); err != nil {
-			return fmt.Errorf("build pack services: %w", err)
+			return "", fmt.Errorf("build pack services: %w", err)
 		}
 	}
-	return nil
+
+	// Only the project name and the runner identity vary between a plan's
+	// cases, and neither reaches image resolution, so resolving here spares
+	// every case a second full parse of both Compose files.
+	images, err := a.output(ctx, a.Root, env, "docker", append(compose, "config", "--images")...)
+	if err != nil {
+		return "", err
+	}
+	return string(images), nil
 }
 
 func (a *App) runPackTestCase(ctx context.Context, baseCompose, runnerImage string, job packTestJob) error {
@@ -369,11 +382,7 @@ func (a *App) runPackTestCase(ctx context.Context, baseCompose, runnerImage stri
 		job.VersionEnv,
 		job.Case.RunnerUser,
 	)
-	images, err := a.output(ctx, a.Root, env, "docker", append(compose, "config", "--images")...)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(a.Out, "Resolved images:\n%s\n", images)
+	fmt.Fprintf(a.Out, "Resolved images:\n%s\n", job.Images)
 
 	setupArgs := append(append(compose, "up", "-d", "--wait"), job.Plan.Services...)
 	setupErr := a.run(ctx, a.Root, env, "docker", setupArgs...)

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -100,7 +100,11 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 	bin := filepath.Join(harness, "bin")
 	baseCompose := filepath.Join(harness, "compose.yaml")
 	runnerImage := packTestRunnerImage(a.Root, invocationID)
+	sharedTools, sharedToolsErr := packTestNeedsSharedTools(plans)
 	preflightErr := func() error {
+		if sharedToolsErr != nil {
+			return sharedToolsErr
+		}
 		if err := os.MkdirAll(bin, 0o755); err != nil {
 			return err
 		}
@@ -111,6 +115,9 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 		if err := a.run(ctx, filepath.Join(a.Root, "tools"), env, "go", "build", "-trimpath", "-o", filepath.Join(bin, "packtest"), "./cmd/packtest"); err != nil {
 			return err
 		}
+		if !sharedTools {
+			return nil
+		}
 		composeEnv := map[string]string{
 			"EMISAR_ROOT":           a.Root,
 			"PACKTEST_RUNNER_IMAGE": runnerImage,
@@ -120,7 +127,9 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 	if preflightErr != nil {
 		return errors.Join(preflightErr, writePackTestFailureReports(reports, plans, requestedVersionEnv, preflightErr))
 	}
-	defer a.removePackTestRunnerImage(runnerImage)
+	if sharedTools {
+		defer a.removePackTestRunnerImage(runnerImage)
+	}
 
 	versionEnvs := make(map[string]map[string]string, len(plans))
 	for _, plan := range plans {
@@ -403,6 +412,36 @@ type packTestComposeService struct {
 type packTestComposeBuild struct {
 	Context string            `yaml:"context"`
 	Args    map[string]string `yaml:"args"`
+}
+
+// packTestNeedsSharedTools reports whether any selected plan reaches the shared
+// client image. Building it pulls eight server images to extract one binary from
+// each, and a pack whose compose replaces runner-tools with a SUT-derived build
+// never runs a byte of it. haproxy is the exception that keeps this a question
+// rather than a rule: its Dockerfile starts FROM the shared image, named through
+// a PACKTEST_RUNNER_IMAGE build arg.
+func packTestNeedsSharedTools(plans []packtest.PlanRef) (bool, error) {
+	for _, plan := range plans {
+		data, err := os.ReadFile(filepath.Join(filepath.Dir(plan.Path), "compose.yaml"))
+		if err != nil {
+			// preparePackTestPlan reports a missing plan compose per pack, with
+			// the name in the message. Assume the shared image is wanted so the
+			// run reaches that error rather than failing here without a pack.
+			return true, nil
+		}
+		var compose packTestComposeFile
+		if err := yaml.Unmarshal(data, &compose); err != nil {
+			return false, fmt.Errorf("parse %s compose: %w", plan.Name, err)
+		}
+		tools, declared := compose.Services["runner-tools"]
+		if !declared || tools.Build.Context == "" {
+			return true, nil
+		}
+		if _, derived := tools.Build.Args["PACKTEST_RUNNER_IMAGE"]; derived {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func packTestBuildServices(path string) ([]string, error) {

--- a/tools/internal/packtest/packtest.go
+++ b/tools/internal/packtest/packtest.go
@@ -90,6 +90,7 @@ type Plan struct {
 	SecretEnv          []string           `yaml:"secret_env,omitempty"`
 	Env                map[string]string  `yaml:"env,omitempty"`
 	Defaults           Defaults           `yaml:"defaults,omitempty"`
+	Shards             int                `yaml:"shards,omitempty"`
 	Cases              []Case             `yaml:"cases"`
 }
 
@@ -106,6 +107,7 @@ type PlanRef struct {
 	Services    []string
 	Versions    []Version
 	Runner      Runner
+	Shards      int
 	Cases       []CaseRef
 }
 
@@ -113,6 +115,8 @@ type MatrixRow struct {
 	Pack    string `json:"pack"`
 	Version string `json:"version"`
 	Digest  string `json:"digest"`
+	Shard   int    `json:"shard"`
+	Shards  int    `json:"shards"`
 }
 
 type Config struct {
@@ -213,7 +217,7 @@ func Discover(packsDir, pattern string, names ...string) ([]PlanRef, error) {
 		}
 		plans = append(plans, PlanRef{
 			Name: name, PackVersion: packVersion, Path: path, Services: plan.Services,
-			Versions: plan.Versions, Runner: plan.Runner, Cases: cases,
+			Versions: plan.Versions, Runner: plan.Runner, Shards: plan.Shards, Cases: cases,
 		})
 	}
 	if len(plans) == 0 {
@@ -338,13 +342,33 @@ func Matrix(plans []PlanRef) []MatrixRow {
 	// push touched no packs.
 	rows := []MatrixRow{}
 	for _, plan := range plans {
+		shards := max(plan.Shards, 1)
 		for _, version := range plan.Versions {
-			rows = append(rows, MatrixRow{
-				Pack: plan.Name, Version: version.Version, Digest: version.Digest,
-			})
+			for shard := 1; shard <= shards; shard++ {
+				rows = append(rows, MatrixRow{
+					Pack: plan.Name, Version: version.Version, Digest: version.Digest,
+					Shard: shard, Shards: shards,
+				})
+			}
 		}
 	}
 	return rows
+}
+
+// SelectShard keeps the cases belonging to one shard. Every case in a plan
+// boots the same SUT, so cost tracks count and dealing round-robin balances
+// the shards without any estimate of how long a case takes.
+func SelectShard(cases []CaseRef, shard, shards int) []CaseRef {
+	if shards <= 1 {
+		return cases
+	}
+	selected := make([]CaseRef, 0, len(cases)/shards+1)
+	for i, test := range cases {
+		if i%shards == shard-1 {
+			selected = append(selected, test)
+		}
+	}
+	return selected
 }
 
 func Validate(plans []PlanRef) error {
@@ -510,6 +534,9 @@ func validatePlan(pack string, plan Plan, actions map[string]actionDefinition) e
 	}
 	if len(plan.Cases) == 0 {
 		return fmt.Errorf("cases must contain at least one behavioral case")
+	}
+	if plan.Shards < 0 || plan.Shards > len(plan.Cases) {
+		return fmt.Errorf("shards must be between 1 and the %d declared cases", len(plan.Cases))
 	}
 	seen := make(map[string]bool, len(plan.Cases))
 	successfulActions := make(map[string]bool, len(plan.Cases))

--- a/tools/internal/packtest/packtest_test.go
+++ b/tools/internal/packtest/packtest_test.go
@@ -3,9 +3,11 @@ package packtest
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -473,6 +475,64 @@ func TestMatrixPreservesPlanAndVersionOrder(t *testing.T) {
 	}
 	if got := plans[0].DefaultVersion(); got.Version != "2" {
 		t.Fatalf("DefaultVersion() = %+v", got)
+	}
+	for _, row := range rows {
+		if row.Shard != 1 || row.Shards != 1 {
+			t.Fatalf("an unsharded plan must still name shard 1 of 1: %+v", row)
+		}
+	}
+}
+
+func TestMatrixExpandsDeclaredShardsPerVersion(t *testing.T) {
+	plans := []PlanRef{{Name: "alpha", Shards: 3, Versions: []Version{
+		{Version: "2", Digest: testDigest("a"), Default: true},
+		{Version: "1", Digest: testDigest("b")},
+	}}}
+	rows := Matrix(plans)
+	if len(rows) != 6 {
+		t.Fatalf("Matrix() = %+v", rows)
+	}
+	for i, row := range rows {
+		wantVersion, wantShard := "2", i+1
+		if i >= 3 {
+			wantVersion, wantShard = "1", i-2
+		}
+		if row.Version != wantVersion || row.Shard != wantShard || row.Shards != 3 {
+			t.Fatalf("rows[%d] = %+v", i, row)
+		}
+	}
+}
+
+func TestSelectShardCoversEveryCaseExactlyOnce(t *testing.T) {
+	cases := make([]CaseRef, 10)
+	for i := range cases {
+		cases[i] = CaseRef{ID: fmt.Sprintf("case.%d", i)}
+	}
+	const shards = 3
+	seen := make(map[string]int, len(cases))
+	sizes := make([]int, 0, shards)
+	for shard := 1; shard <= shards; shard++ {
+		selected := SelectShard(cases, shard, shards)
+		sizes = append(sizes, len(selected))
+		for _, test := range selected {
+			seen[test.ID]++
+		}
+	}
+	if len(seen) != len(cases) {
+		t.Fatalf("shards covered %d of %d cases", len(seen), len(cases))
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("case %s ran %d times across the shards", id, count)
+		}
+	}
+	// Ten cases over three shards: nothing may be off by more than one, or a
+	// shard becomes the row everyone waits for.
+	if slices.Max(sizes)-slices.Min(sizes) > 1 {
+		t.Fatalf("shard sizes are unbalanced: %v", sizes)
+	}
+	if got := SelectShard(cases, 1, 1); len(got) != len(cases) {
+		t.Fatalf("a single shard must keep every case, got %d", len(got))
 	}
 }
 


### PR DESCRIPTION
The behavior matrix ran 43 jobs / 129 runner-minutes / ~33 minutes of wall clock.
Roughly a third of that was the same work repeated per job, and most of the rest
was cases waiting on a health poll rather than on their server.

Measured on run 30216913429, then again locally:

- The shared client image was rebuilt from scratch in every job — eight server
  images pulled to extract one binary from each, plus a 22s apt install, ~40s.
  Ten of the 43 rows built that 2.79GB image, never ran a byte of it, and
  deleted it: those packs replace `runner-tools` with a SUT-derived image.
- The tag hashed the checkout path and the invocation id, so nothing could ever
  reuse it. It now hashes the Dockerfile, which COPYs nothing from its context.
- Each row cross-compiled the runner and harness against setup-go's shared
  cache, whose objects were built by another job under different flags.
- Docker runs a container's first health check only after a full interval, so
  `up --wait` on a redis ready in under a second returned after 10.8s. With a
  start period and a one-second start interval it returns in 1.7s. That delay
  was on all 651 cases; `./run test packs redis` drops from 49s to 22s.
- cassandra and kubernetes boot for about a minute per case and were both ends
  of the critical path at 759s and 683s. Their plans now declare a shard count.

Tightening readiness exposed three fixture races the coarse poll had been
covering for. mongodb and postgres health-checked loopback, which the
entrypoint's temporary seeding daemon binds and the real one has not reached —
healthy SUT, `ECONNREFUSED` case. cockroach read a statistic `ANALYZE` had not
published yet. The rule card carries the general shape and its sweep signal.

Verified: all 34 packs green (266/266 across the 24 not checked individually,
ten more run one at a time); cassandra's four shards cover exactly its 32 cases
with no duplicates or drops; `./run gate packs`, `./run gate tooling`, and
actionlint 1.7.12 all exit 0.

The CI-side numbers are the part this run has to prove — the image restore and
the concurrency raise have been reasoned about, not watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)