### PR TITLE
Make CI the recorded authority for what a workstation cannot judge

### DIFF
--- a/.agent/kb/rules/packs-fixtures-match-the-isolated-nonroot-sut.md
+++ b/.agent/kb/rules/packs-fixtures-match-the-isolated-nonroot-sut.md
@@ -35,7 +35,13 @@ up itself. Three shapes to recognize:
    writes `.erlang.cookie` before the entrypoint does, and the server it then
    starts cannot read the file. Give a check that writes anything a probe no
    earlier than the entrypoint's own setup: `start_period` alone still polls at
-   `interval`, which is the safe cadence for this class.
+   `interval`, which is the safe cadence for this class. **Poll cost scales with
+   probe cost**, too — a check that spawns a JVM, a BEAM node, `kubectl`, or any
+   language-runtime client is re-spawned on every poll, four cases at a time, on
+   a four-core runner. k3s ran three `kubectl` calls a second through a
+   two-minute start period and its apiserver died on an IP-allocation check.
+   Thin probes (`nc`, `curl`, `redis-cli`, `pg_isready`) may poll at 1s; a probe
+   that spawns a heavyweight client polls no faster than 5s.
 
 **Why.** The isolation hardening was the point: a case that shares a server with
 its neighbours proves nothing about the action, and a root runner hides every
@@ -109,4 +115,6 @@ name implies cumulative counters (`top`, `*_stats`, profilers) with no
 `arrange:`; a case whose command is documented as superuser-only but declares
 no `runner_user`; and a `healthcheck.test` naming `localhost`, `127.0.0.1`, or
 a bare socket on an image that seeds through `docker-entrypoint-initdb.d`; and
-a sub-second `start_interval` on a check that writes state rather than reads it.
+a sub-second `start_interval` on a check that writes state rather than reads it,
+or a `start_interval` under 5s on one that spawns a heavyweight client — parse
+the Compose YAML to count those, since the commands span several lines.

--- a/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
+++ b/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
@@ -44,6 +44,14 @@ coop tasks done <id>
 coop tasks done <id>        # the class this touched was never judged
 ```
 
+**Judge a CI change on the constraint that actually binds.** The shared client
+image is cached in CI despite costing more wall clock than rebuilding it — the
+build pulls eight server images to extract one binary each, and the registry, not
+the clock, is what runs out. Removing the cache on a timing argument traded two
+registry round trips per row for nine and turned one occasional failure into
+three in a single run. Measure the binding constraint before optimising the
+visible one.
+
 **A shared quota is a CI-only limit too.** Docker Hub rate-limits anonymous
 pulls per address, and a runner pool shares addresses, so matrix width is bounded
 by the registry rather than by CPU. Twelve concurrent rows returned

--- a/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
+++ b/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
@@ -44,6 +44,13 @@ coop tasks done <id>
 coop tasks done <id>        # the class this touched was never judged
 ```
 
+**A shared quota is a CI-only limit too.** Docker Hub rate-limits anonymous
+pulls per address, and a runner pool shares addresses, so matrix width is bounded
+by the registry rather than by CPU. Twelve concurrent rows returned
+`unauthorized: authentication required` and a connection timeout twice in five
+runs; a workstation pulling one image at a time never sees it. Raise matrix width
+in steps and read the next few runs for registry errors before trusting it.
+
 **One green run is one sample.** A suite this shape is flaky until shown
 otherwise, so a single green CI run is evidence, not proof. Re-run the job that
 failed before merging on its recovery — zookeeper went green, then failed a

--- a/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
+++ b/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
@@ -1,0 +1,55 @@
+# CI decides what a workstation cannot
+
+**Rule.** Some surfaces are judged by CI and only CI. For those, a change is not
+done when the local gate is green — it is done when the CI job is green. Do not
+mark the task done, and do not fold the work into a commit you would defend,
+until you have read that job.
+
+Surfaces where a workstation returns a false pass:
+
+| Surface | What the local run cannot see |
+|---|---|
+| `packs/*/test/` | uid ownership and AppArmor (Docker Desktop's VM masks both), and any startup race a machine with spare cores wins |
+| `.github/workflows/` | the runner's toolchain and the state actions leave behind — a buildx driver selected for the rest of the job has its own image store |
+| `dev/test-packs/` | both of the above, for every pack at once |
+
+**Why.** Three fixtures shipped broken in one change because a green local run
+read as a verdict. rabbitmq's health check raced the entrypoint writing
+`.erlang.cookie`: thirteen of fourteen cases lost that race on a four-core
+runner and none lost it on a twelve-core workstation. zookeeper's readiness
+proved loopback while its cases dial the bridge. haproxy's client image resolved
+its base against the registry because `setup-buildx-action` leaves a
+container-driver builder selected. None of the three could fail locally, so each
+was "verified" and each was wrong — and the fixes landed as follow-up commits,
+leaving two commits in `main` that would fail CI if checked out.
+
+The trap is not ignorance of this; the rule card for pack fixtures already said
+a workstation cannot judge that class. The trap is finishing a long local run,
+reading `266/266 PASS`, and treating the number as the answer to a question it
+was never asked.
+
+**✅ Good**
+
+```
+# Push for the verdict, then finish the task.
+git push -u origin <branch> && gh pr create ...   # read the matrix
+git rebase -i origin/main                          # fold fixes into their commit
+coop tasks done <id>
+```
+
+**❌ Bad**
+
+```
+./run test packs            # 266/266 PASS on a Mac
+coop tasks done <id>        # the class this touched was never judged
+```
+
+**How it's enforced.** `./run test packs` ends a passing run by naming what this
+host could not decide — file ownership, AppArmor, startup races — and pointing
+at the Linux matrix. It reports the limits rather than failing, because
+iterating locally is the point; what it refuses to do is let the pass count
+stand as a verdict. `packTestHostBlindSpots` is unit-tested against a
+workstation, Docker Desktop on Linux, a roomy Linux host, and a runner-shaped
+host. Sweep signal: a task moved to `99_done/` whose commit touches one of the
+surfaces above with no CI run read for it, and a fix commit whose message
+repairs the commit immediately before it.

--- a/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
+++ b/.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md
@@ -44,6 +44,13 @@ coop tasks done <id>
 coop tasks done <id>        # the class this touched was never judged
 ```
 
+**One green run is one sample.** A suite this shape is flaky until shown
+otherwise, so a single green CI run is evidence, not proof. Re-run the job that
+failed before merging on its recovery — zookeeper went green, then failed a
+re-run of the same commit, then failed again on a third fix. Three readiness
+fixes each moved its failure to a different case before the honest answer turned
+out to be that the pack keeps its slower readiness.
+
 **How it's enforced.** `./run test packs` ends a passing run by naming what this
 host could not decide — file ownership, AppArmor, startup races — and pointing
 at the Linux matrix. It reports the limits rather than failing, because

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,7 +561,7 @@ jobs:
         run: ./run check packs
 
   pack-tools:
-    name: Packs - Behavior client image
+    name: Packs - Behavior build cache
     needs: changes
     if: needs.changes.outputs.pack_behavior != '[]'
     runs-on: ubuntu-latest
@@ -599,25 +599,6 @@ jobs:
           go -C runner build -trimpath -o /dev/null .
           go -C tools build -trimpath -o /dev/null ./cmd/packtest
 
-      - id: tools
-        name: Resolve the shared client image
-        run: echo "image=$(./run pack tools-image)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      # One writer for the whole matrix. Every behavior row restores this entry
-      # instead of pulling eight servers to extract one binary from each, and
-      # letting the rows write it back would mean dozens of concurrent uploads
-      # of the same 2GB image the first time the Dockerfile changes.
-      - name: Populate the shared client image cache
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: dev/test-packs
-          load: true
-          tags: ${{ steps.tools.outputs.image }}
-          cache-from: type=gha,scope=packtest-tools
-          cache-to: type=gha,mode=min,scope=packtest-tools
 
   pack-behavior:
     name: Packs - Behavior (${{ matrix.pack }} ${{ matrix.version }}${{ matrix.shards > 1 && format(' shard {0}/{1}', matrix.shard, matrix.shards) || '' }})
@@ -662,33 +643,6 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
-
-      # Empty for a pack that ships its own client image, which then needs
-      # neither the builder nor the restore.
-      - id: tools
-        name: Resolve the shared client image
-        run: echo "image=$(./run pack tools-image "$PACK")" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        if: steps.tools.outputs.image != ''
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Restore the shared client image
-        if: steps.tools.outputs.image != ''
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: dev/test-packs
-          load: true
-          tags: ${{ steps.tools.outputs.image }}
-          cache-from: type=gha,scope=packtest-tools
-
-      # setup-buildx-action leaves its container-driver builder selected for the
-      # rest of the job, and that builder has its own image store. A pack whose
-      # client image starts FROM the shared one would resolve that base against
-      # the registry and fail; the daemon is where the restore just loaded it.
-      - name: Build against the daemon's image store
-        if: steps.tools.outputs.image != ''
-        run: docker buildx use default
 
       - name: Exercise pack behavior
         run: ./run test packs "$PACK" --shard "$SHARD"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,10 +627,12 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # 57 rows of mostly-idle Docker waits. The cap was low to spare Docker
-      # Hub, which reusing the shared client image relieved: a row now pulls
-      # its own SUT rather than nine images it mostly never runs.
-      max-parallel: 12
+      # Rows are mostly idle Docker waits, so the cap is about Docker Hub, not
+      # CPU. Reusing the shared client image relieved it — a row pulls its own
+      # SUT rather than nine images it mostly never runs — but twelve was too
+      # far: anonymous pulls came back "unauthorized" and timed out twice in
+      # five runs. Eight keeps most of the wall-clock win with headroom.
+      max-parallel: 8
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.pack_behavior) }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,7 +561,7 @@ jobs:
         run: ./run check packs
 
   pack-tools:
-    name: Packs - Behavior build cache
+    name: Packs - Behavior client image
     needs: changes
     if: needs.changes.outputs.pack_behavior != '[]'
     runs-on: ubuntu-latest
@@ -599,6 +599,25 @@ jobs:
           go -C runner build -trimpath -o /dev/null .
           go -C tools build -trimpath -o /dev/null ./cmd/packtest
 
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # One writer for the whole matrix. Every behavior row restores this entry
+      # instead of pulling eight servers to extract one binary from each, and
+      # letting the rows write it back would mean dozens of concurrent uploads
+      # of the same 2GB image the first time the Dockerfile changes.
+      - name: Populate the shared client image cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
+          cache-to: type=gha,mode=min,scope=packtest-tools
 
   pack-behavior:
     name: Packs - Behavior (${{ matrix.pack }} ${{ matrix.version }}${{ matrix.shards > 1 && format(' shard {0}/{1}', matrix.shard, matrix.shards) || '' }})
@@ -643,6 +662,33 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
+
+      # Empty for a pack that ships its own client image, which then needs
+      # neither the builder nor the restore.
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image "$PACK")" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.tools.outputs.image != ''
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Restore the shared client image
+        if: steps.tools.outputs.image != ''
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
+
+      # setup-buildx-action leaves its container-driver builder selected for the
+      # rest of the job, and that builder has its own image store. A pack whose
+      # client image starts FROM the shared one would resolve that base against
+      # the registry and fail; the daemon is where the restore just loaded it.
+      - name: Build against the daemon's image store
+        if: steps.tools.outputs.image != ''
+        run: docker buildx use default
 
       - name: Exercise pack behavior
         run: ./run test packs "$PACK" --shard "$SHARD"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,12 +627,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # Rows are mostly idle Docker waits, so the cap is about Docker Hub, not
-      # CPU. Reusing the shared client image relieved it — a row pulls its own
-      # SUT rather than nine images it mostly never runs — but twelve was too
-      # far: anonymous pulls came back "unauthorized" and timed out twice in
-      # five runs. Eight keeps most of the wall-clock win with headroom.
-      max-parallel: 8
+      # EXPERIMENT, not a conclusion: back at the pre-change width to test
+      # whether concurrency is what makes zookeeper's four-letter word flake.
+      # Restore the raise once that question has an answer.
+      max-parallel: 4
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.pack_behavior) }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,10 +627,11 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # EXPERIMENT, not a conclusion: back at the pre-change width to test
-      # whether concurrency is what makes zookeeper's four-letter word flake.
-      # Restore the raise once that question has an answer.
-      max-parallel: 4
+      # Rows are mostly idle Docker waits, so the cap is about Docker Hub, not
+      # CPU: a row pulls the shared client image from cache plus its own SUT.
+      # Twelve was too wide — anonymous pulls came back "unauthorized" and timed
+      # out. Eight held. Raise this in steps and read several runs, not one.
+      max-parallel: 8
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.pack_behavior) }}
     env:

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -78,10 +78,11 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # EXPERIMENT, not a conclusion: back at the pre-change width to test
-      # whether concurrency is what makes zookeeper's four-letter word flake.
-      # Restore the raise once that question has an answer.
-      max-parallel: 4
+      # Rows are mostly idle Docker waits, so the cap is about Docker Hub, not
+      # CPU: a row pulls the shared client image from cache plus its own SUT.
+      # Twelve was too wide — anonymous pulls came back "unauthorized" and timed
+      # out. Eight held. Raise this in steps and read several runs, not one.
+      max-parallel: 8
       matrix:
         include: ${{ fromJSON(needs.plans.outputs.matrix) }}
     env:

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -78,12 +78,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # Rows are mostly idle Docker waits, so the cap is about Docker Hub, not
-      # CPU. Reusing the shared client image relieved it — a row pulls its own
-      # SUT rather than nine images it mostly never runs — but twelve was too
-      # far: anonymous pulls came back "unauthorized" and timed out twice in
-      # five runs. Eight keeps most of the wall-clock win with headroom.
-      max-parallel: 8
+      # EXPERIMENT, not a conclusion: back at the pre-change width to test
+      # whether concurrency is what makes zookeeper's four-letter word flake.
+      # Restore the raise once that question has an answer.
+      max-parallel: 4
       matrix:
         include: ${{ fromJSON(needs.plans.outputs.matrix) }}
     env:

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -78,10 +78,12 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      # 57 rows of mostly-idle Docker waits. The cap was low to spare Docker
-      # Hub, which reusing the shared client image relieved: a row now pulls
-      # its own SUT rather than nine images it mostly never runs.
-      max-parallel: 12
+      # Rows are mostly idle Docker waits, so the cap is about Docker Hub, not
+      # CPU. Reusing the shared client image relieved it — a row pulls its own
+      # SUT rather than nine images it mostly never runs — but twelve was too
+      # far: anonymous pulls came back "unauthorized" and timed out twice in
+      # five runs. Eight keeps most of the wall-clock win with headroom.
+      max-parallel: 8
       matrix:
         include: ${{ fromJSON(needs.plans.outputs.matrix) }}
     env:

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -54,22 +54,6 @@ jobs:
           go -C runner build -trimpath -o /dev/null .
           go -C tools build -trimpath -o /dev/null ./cmd/packtest
 
-      - id: tools
-        name: Resolve the shared client image
-        run: echo "image=$(./run pack tools-image)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      # One writer for the whole matrix; the rows below only restore.
-      - name: Populate the shared client image cache
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: dev/test-packs
-          load: true
-          tags: ${{ steps.tools.outputs.image }}
-          cache-from: type=gha,scope=packtest-tools
-          cache-to: type=gha,mode=min,scope=packtest-tools
 
   behavior:
     name: ${{ matrix.pack }} ${{ matrix.version }}${{ matrix.shards > 1 && format(' shard {0}/{1}', matrix.shard, matrix.shards) || '' }}
@@ -113,33 +97,6 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
-
-      # Empty for a pack that ships its own client image, which then needs
-      # neither the builder nor the restore.
-      - id: tools
-        name: Resolve the shared client image
-        run: echo "image=$(./run pack tools-image "$PACK")" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        if: steps.tools.outputs.image != ''
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Restore the shared client image
-        if: steps.tools.outputs.image != ''
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: dev/test-packs
-          load: true
-          tags: ${{ steps.tools.outputs.image }}
-          cache-from: type=gha,scope=packtest-tools
-
-      # setup-buildx-action leaves its container-driver builder selected for the
-      # rest of the job, and that builder has its own image store. A pack whose
-      # client image starts FROM the shared one would resolve that base against
-      # the registry and fail; the daemon is where the restore just loaded it.
-      - name: Build against the daemon's image store
-        if: steps.tools.outputs.image != ''
-        run: docker buildx use default
 
       - name: Exercise pack behavior
         run: ./run test packs "$PACK" --shard "$SHARD"

--- a/.github/workflows/pack-behavior.yml
+++ b/.github/workflows/pack-behavior.yml
@@ -54,6 +54,22 @@ jobs:
           go -C runner build -trimpath -o /dev/null .
           go -C tools build -trimpath -o /dev/null ./cmd/packtest
 
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # One writer for the whole matrix; the rows below only restore.
+      - name: Populate the shared client image cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
+          cache-to: type=gha,mode=min,scope=packtest-tools
 
   behavior:
     name: ${{ matrix.pack }} ${{ matrix.version }}${{ matrix.shards > 1 && format(' shard {0}/{1}', matrix.shard, matrix.shards) || '' }}
@@ -97,6 +113,33 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: packtest-go-${{ runner.os }}-${{ hashFiles('runner/go.sum', 'tools/go.sum') }}
+
+      # Empty for a pack that ships its own client image, which then needs
+      # neither the builder nor the restore.
+      - id: tools
+        name: Resolve the shared client image
+        run: echo "image=$(./run pack tools-image "$PACK")" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        if: steps.tools.outputs.image != ''
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Restore the shared client image
+        if: steps.tools.outputs.image != ''
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: dev/test-packs
+          load: true
+          tags: ${{ steps.tools.outputs.image }}
+          cache-from: type=gha,scope=packtest-tools
+
+      # setup-buildx-action leaves its container-driver builder selected for the
+      # rest of the job, and that builder has its own image store. A pack whose
+      # client image starts FROM the shared one would resolve that base against
+      # the registry and fail; the daemon is where the restore just loaded it.
+      - name: Build against the daemon's image store
+        if: steps.tools.outputs.image != ''
+        run: docker buildx use default
 
       - name: Exercise pack behavior
         run: ./run test packs "$PACK" --shard "$SHARD"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Each project has an `.agent/` folder — durable working memory the BOOT protoco
 A task moves to `99_done/` (via `coop tasks done`) only when **all** of these hold:
 
 - the project gate ran **green** (exact command in the project `AGENTS.md`),
+- **for a change to `packs/*/test/`, `.github/workflows/`, or `dev/test-packs/`, the CI job ran green too** — a workstation cannot judge those (uid ownership, AppArmor, startup races, runner toolchain), so the local gate is a false pass there. Push for the verdict, read the job, and fold any fix into the commit it repairs rather than trailing it ([rule](.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md)),
 - the change is **committed** — one focused commit per task, carrying its `Coop-Task: <id>` trailer,
 - the task's own `log.md` says *why* (decisions, dead ends — the audit and the next agent read it), and its `state.md` reflects the finished state.
 
@@ -170,6 +171,7 @@ goes through `coop fork` (each fork is its own clone) — never two writers in o
 - **Shared:** [browser security exceptions stay response-local](.agent/kb/rules/shared-browser-security-exceptions-stay-response-local.md) — external integration compatibility relaxations happen only after request validation, on the exact response that needs them, with fixed application-controlled targets.
 - **Shared:** [model catalogs expose only trusted pack refs](.agent/kb/rules/shared-model-catalog-trusted-only.md) — filter non-trusted exact pack refs before deriving any model-visible action, runner, runbook, issue, or continuation; mutations still recheck trust transactionally.
 - **Shared:** [reversible and terminal runner states stay distinct](.agent/kb/rules/shared-runner-lifecycle-states.md) — disable keeps the identity retryable so enable recovers without host access; delete/revoke is terminal and never inherits retry behavior.
+- **Shared:** [CI decides what a workstation cannot](.agent/kb/rules/shared-ci-decides-what-a-workstation-cannot.md) — pack fixtures, workflows, and the behavior harness are judged by the Linux matrix and only by it; a green local run there is a false pass, so read the job before marking the task done.
 - **Shared:** [every blocking check lives inside the canonical gate](.agent/kb/rules/shared-checks-live-in-the-canonical-gate.md) — CI reaches a check by invoking `./run gate`, never by running the tool in its own step; a CI-only check makes a green gate a false promise and hides findings until someone pushes.
 
 When the user corrects something — a naming call, a "use X not Y," a structural nit — it is a **rule**, not a one-off fix. In the **same change**:

--- a/packs/cassandra/test/compose.yaml
+++ b/packs/cassandra/test/compose.yaml
@@ -46,7 +46,9 @@ services:
           INSERT INTO packtest.events (id, value) VALUES (1, 'ready');" >/dev/null && exit 1))
       interval: 10s
       start_period: 120s
-      start_interval: 2s
+      # Poll cost scales with probe cost: this check spawns a heavyweight
+      # client, and four cases boot at once on a four-core runner.
+      start_interval: 5s
       timeout: 10s
       retries: 30
     volumes:

--- a/packs/clickhouse/test/compose.yaml
+++ b/packs/clickhouse/test/compose.yaml
@@ -16,5 +16,7 @@ services:
       test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' >/dev/null && sleep 2 && clickhouse-client --query 'SELECT 1' >/dev/null"]
       interval: 5s
       start_period: 30s
-      start_interval: 1s
+      # Poll cost scales with probe cost: this check spawns a heavyweight
+      # client, and four cases boot at once on a four-core runner.
+      start_interval: 5s
       retries: 10

--- a/packs/kubernetes/test/cases.yaml
+++ b/packs/kubernetes/test/cases.yaml
@@ -13,6 +13,10 @@ versions:
 # across matrix rows instead of sharing a cluster between them.
 shards: 5
 
+# Each case boots a full k3s control plane. Four at once on a four-core runner
+# starves the apiserver and it dies on its IP-allocation check.
+workers: 2
+
 env:
   KUBECONFIG: /shared/kubeconfig.yaml
 defaults:

--- a/packs/kubernetes/test/cases.yaml
+++ b/packs/kubernetes/test/cases.yaml
@@ -139,6 +139,11 @@ cases:
       stdout_contains: [harness-deployment, REVISION]
   - action: kubernetes.rollout_status
     args: {namespace: default, kind: deployment, name: harness-deployment}
+    # Readiness proves the node, the probe pod and the CRD; it says nothing
+    # about this deployment's replicas, so the case waits for the state it
+    # then asserts on.
+    arrange:
+      - argv: [kubectl, rollout, status, deployment/harness-deployment, --namespace, default, --timeout, 120s]
     expect:
       stdout_contains: [successfully rolled out]
   - action: kubernetes.services_list

--- a/packs/kubernetes/test/compose.yaml
+++ b/packs/kubernetes/test/compose.yaml
@@ -17,7 +17,9 @@ services:
       test: ["CMD-SHELL", "kubectl get nodes | grep -q ' Ready' && kubectl wait --for=condition=Ready pod/probe --timeout=2s >/dev/null && kubectl get crd harnesses.packtest.emisar.dev >/dev/null"]
       interval: 10s
       start_period: 120s
-      start_interval: 1s
+      # Poll cost scales with probe cost: this check spawns a heavyweight
+      # client, and four cases boot at once on a four-core runner.
+      start_interval: 5s
       retries: 30
 
   k3s-kubeconfig:

--- a/packs/mongodb/test/compose.yaml
+++ b/packs/mongodb/test/compose.yaml
@@ -14,5 +14,7 @@ services:
       test: ["CMD-SHELL", "mongosh --host \"$$(hostname -i)\" --quiet --eval \"db.adminCommand('ping').ok\""]
       interval: 10s
       start_period: 30s
-      start_interval: 1s
+      # Poll cost scales with probe cost: this check spawns a heavyweight
+      # client, and four cases boot at once on a four-core runner.
+      start_interval: 5s
       retries: 10

--- a/packs/mysql/test/compose.yaml
+++ b/packs/mysql/test/compose.yaml
@@ -10,5 +10,7 @@ services:
       test: ["CMD-SHELL", "mysql -h 127.0.0.1 -uroot -ppacktest-canary-mysql-root-b813 -Nse 'SELECT COUNT(*) FROM testdb.orders' >/dev/null"]
       interval: 2s
       start_period: 30s
-      start_interval: 1s
+      # Poll cost scales with probe cost: this check spawns a heavyweight
+      # client, and four cases boot at once on a four-core runner.
+      start_interval: 5s
       retries: 30

--- a/packs/zookeeper/test/compose.yaml
+++ b/packs/zookeeper/test/compose.yaml
@@ -6,6 +6,11 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep -q imok"]
+      # Readiness has to prove what the cases actually do. A four-letter word
+      # against a recently-started node gets its connection closed empty, one
+      # command at a time and not always the same one, so proving ruok proves
+      # nothing about conf. Require every command the cases use to answer,
+      # over the bridge they dial.
+      test: ["CMD-SHELL", "for c in conf cons envi mntr ruok srvr stat wchs; do echo $$c | nc -w 2 \"$$(hostname -i)\" 2181 | grep -q . || exit 1; done"]
       interval: 5s
       retries: 10

--- a/packs/zookeeper/test/compose.yaml
+++ b/packs/zookeeper/test/compose.yaml
@@ -6,10 +6,12 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      # Every case reaches 2181 over the bridge, so readiness has to prove
-      # that path: loopback answers ruok while a bridge connection still
-      # gets closed empty, and faster readiness starts cases in that gap.
-      test: ["CMD-SHELL", "echo ruok | nc -w 2 \"$$(hostname -i)\" 2181 | grep -q imok"]
+      # ruok answers imok before the server serves requests — that is what it
+      # documents itself as doing — so a ruok probe reports ready while every
+      # other four-letter word still gets its connection closed empty. srvr
+      # prints Mode only once the server is actually serving, over the bridge
+      # every case dials.
+      test: ["CMD-SHELL", "echo srvr | nc -w 2 \"$$(hostname -i)\" 2181 | grep -q Mode"]
       interval: 5s
       start_period: 30s
       start_interval: 1s

--- a/packs/zookeeper/test/compose.yaml
+++ b/packs/zookeeper/test/compose.yaml
@@ -6,18 +6,6 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     healthcheck:
-      # ruok answers imok before the server serves requests — that is what it
-      # documents itself as doing — so a ruok probe reports ready while every
-      # other four-letter word still gets its connection closed empty. srvr
-      # prints Mode only once the server is actually serving, over the bridge
-      # every case dials.
-      test: ["CMD-SHELL", "echo srvr | nc -w 2 \"$$(hostname -i)\" 2181 | grep -q Mode"]
-      # This pack opts out of fast readiness, deliberately. A four-letter word
-      # against a freshly-serving node intermittently comes back empty — three
-      # runs failed one random case each (ruok, conf, wchs) while srvr answered
-      # in the same run, so readiness is not the lever and a stronger probe did
-      # not help. The interval that was green for months starts cases about ten
-      # seconds in, which is the margin this pack needs. Eight seconds on one
-      # job is not worth a flaky matrix; do not "optimize" this back.
+      test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 5s
       retries: 10

--- a/packs/zookeeper/test/compose.yaml
+++ b/packs/zookeeper/test/compose.yaml
@@ -12,7 +12,12 @@ services:
       # prints Mode only once the server is actually serving, over the bridge
       # every case dials.
       test: ["CMD-SHELL", "echo srvr | nc -w 2 \"$$(hostname -i)\" 2181 | grep -q Mode"]
+      # This pack opts out of fast readiness, deliberately. A four-letter word
+      # against a freshly-serving node intermittently comes back empty — three
+      # runs failed one random case each (ruok, conf, wchs) while srvr answered
+      # in the same run, so readiness is not the lever and a stronger probe did
+      # not help. The interval that was green for months starts cases about ten
+      # seconds in, which is the margin this pack needs. Eight seconds on one
+      # job is not worth a flaky matrix; do not "optimize" this back.
       interval: 5s
-      start_period: 30s
-      start_interval: 1s
       retries: 10

--- a/tools/internal/devtool/devtool_test.go
+++ b/tools/internal/devtool/devtool_test.go
@@ -319,6 +319,32 @@ func TestPackTestRunnerImageTracksTheDockerfile(t *testing.T) {
 	}
 }
 
+func TestPackTestHostBlindSpots(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		dockerOS string
+		cores    int
+		want     int
+	}{
+		{name: "workstation", goos: "darwin", dockerOS: "Docker Desktop", cores: 12, want: 3},
+		{name: "Docker Desktop on Linux", goos: "linux", dockerOS: "Docker Desktop", cores: 4, want: 2},
+		{name: "roomy Linux host", goos: "linux", dockerOS: "Ubuntu 24.04.4 LTS", cores: 32, want: 1},
+		{name: "CI runner", goos: "linux", dockerOS: "Ubuntu 24.04.4 LTS", cores: 4, want: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := packTestHostBlindSpots(test.goos, test.dockerOS, test.cores); len(got) != test.want {
+				t.Fatalf("blind spots = %v, want %d", got, test.want)
+			}
+		})
+	}
+	if notice := packTestVerdictNotice([]string{"file ownership"}); !strings.Contains(notice, "authority") ||
+		!strings.Contains(notice, "file ownership") {
+		t.Fatalf("notice must name the limit and the authority: %q", notice)
+	}
+}
+
 func TestPackTestNeedsSharedTools(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/tools/internal/devtool/gates.go
+++ b/tools/internal/devtool/gates.go
@@ -63,8 +63,6 @@ const (
   check <name>               validate one pack without changing artifacts
   hashes [--write]           verify or refresh cross-language pack hash goldens
   sync <name> --fix          rebuild the catalog from the live registry history
-  tools-image [<name>]       print the shared behavior client image tag, or
-                             nothing when the named pack ships its own client
 
 Use "./run test packs [name-pattern]" for pack-owned behavior cases and
 "./run gate packs" for the complete pack Definition of Done.

--- a/tools/internal/devtool/gates.go
+++ b/tools/internal/devtool/gates.go
@@ -63,6 +63,8 @@ const (
   check <name>               validate one pack without changing artifacts
   hashes [--write]           verify or refresh cross-language pack hash goldens
   sync <name> --fix          rebuild the catalog from the live registry history
+  tools-image [<name>]       print the shared behavior client image tag, or
+                             nothing when the named pack ships its own client
 
 Use "./run test packs [name-pattern]" for pack-owned behavior cases and
 "./run gate packs" for the complete pack Definition of Done.

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -164,7 +164,7 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 	}
 	close(jobs)
 
-	workerCount := min(4, len(queued))
+	workerCount := min(packtest.Workers(plans), len(queued))
 	var workers sync.WaitGroup
 	workers.Add(workerCount)
 	for range workerCount {

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -247,7 +247,50 @@ func (a *App) packTest(ctx context.Context, pattern string, names []string, case
 			}
 		}
 	}
+	if len(failures) == 0 {
+		if limits := packTestHostBlindSpots(runtime.GOOS, a.dockerHostOS(ctx), runtime.NumCPU()); len(limits) > 0 {
+			fmt.Fprintf(a.Out, "\n%s\n", packTestVerdictNotice(limits))
+		}
+	}
 	return errors.Join(failures...)
+}
+
+// packTestHostBlindSpots names what this host's Docker cannot decide. A green
+// run here is real evidence about an action's behavior and no evidence at all
+// about the isolated, non-root SUT the Linux matrix runs: Docker Desktop's VM
+// masks uid ownership and loads no AppArmor profile, and a workstation with
+// cores to spare wins startup races a two-to-four core runner loses.
+func packTestHostBlindSpots(goos, dockerOS string, cores int) []string {
+	var limits []string
+	if strings.Contains(dockerOS, "Docker Desktop") || goos != "linux" {
+		limits = append(limits,
+			"file ownership and permission errors — the VM masks container uid ownership",
+			"anything AppArmor confines — no profile is loaded here",
+		)
+	}
+	// A GitHub runner has four cores; more than that here wins races it loses.
+	if goos != "linux" || cores > 4 {
+		limits = append(limits,
+			"startup races — a runner has fewer cores and loses races this host wins",
+		)
+	}
+	return limits
+}
+
+func packTestVerdictNotice(limits []string) string {
+	notice := "Passed here, which does not decide:\n"
+	for _, limit := range limits {
+		notice += "  - " + limit + "\n"
+	}
+	return notice + "The Linux pack behavior matrix is the authority for those. Read the job."
+}
+
+func (a *App) dockerHostOS(ctx context.Context) string {
+	output, err := a.output(ctx, a.Root, nil, "docker", "info", "--format", "{{.OperatingSystem}}")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }
 
 // selectPackTestShard keeps one slice of a single pack's cases. A pack whose

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -746,6 +746,34 @@ func (a *App) pack(ctx context.Context, args []string) error {
 		return usage("%s", packUsage)
 	}
 	action := args[0]
+	if action == "tools-image" {
+		if len(args) > 2 {
+			return usage("usage: ./run pack tools-image [<pack-name>]")
+		}
+		image, err := packTestRunnerImage(a.Root)
+		if err != nil {
+			return err
+		}
+		if len(args) == 2 {
+			// Named, the question is whether this pack reaches the image at
+			// all: a pack that ships its own client wants no part of it, and
+			// printing nothing is what lets CI skip restoring 2GB it will not
+			// run.
+			plans, err := packtest.Discover(filepath.Join(a.Root, "packs"), "", args[1])
+			if err != nil {
+				return err
+			}
+			needed, err := packTestNeedsSharedTools(plans)
+			if err != nil {
+				return err
+			}
+			if !needed {
+				return nil
+			}
+		}
+		fmt.Fprintln(a.Out, image)
+		return nil
+	}
 	if action == "hashes" {
 		if len(args) > 2 || len(args) == 2 && args[1] != "--write" {
 			return usage("usage: ./run pack hashes [--write]")

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -746,34 +746,6 @@ func (a *App) pack(ctx context.Context, args []string) error {
 		return usage("%s", packUsage)
 	}
 	action := args[0]
-	if action == "tools-image" {
-		if len(args) > 2 {
-			return usage("usage: ./run pack tools-image [<pack-name>]")
-		}
-		image, err := packTestRunnerImage(a.Root)
-		if err != nil {
-			return err
-		}
-		if len(args) == 2 {
-			// Named, the question is whether this pack reaches the image at
-			// all: a pack that ships its own client wants no part of it, and
-			// printing nothing is what lets CI skip restoring 2GB it will not
-			// run.
-			plans, err := packtest.Discover(filepath.Join(a.Root, "packs"), "", args[1])
-			if err != nil {
-				return err
-			}
-			needed, err := packTestNeedsSharedTools(plans)
-			if err != nil {
-				return err
-			}
-			if !needed {
-				return nil
-			}
-		}
-		fmt.Fprintln(a.Out, image)
-		return nil
-	}
 	if action == "hashes" {
 		if len(args) > 2 || len(args) == 2 && args[1] != "--write" {
 			return usage("usage: ./run pack hashes [--write]")

--- a/tools/internal/packtest/packtest.go
+++ b/tools/internal/packtest/packtest.go
@@ -91,6 +91,7 @@ type Plan struct {
 	Env                map[string]string  `yaml:"env,omitempty"`
 	Defaults           Defaults           `yaml:"defaults,omitempty"`
 	Shards             int                `yaml:"shards,omitempty"`
+	Workers            int                `yaml:"workers,omitempty"`
 	Cases              []Case             `yaml:"cases"`
 }
 
@@ -108,6 +109,7 @@ type PlanRef struct {
 	Versions    []Version
 	Runner      Runner
 	Shards      int
+	Workers     int
 	Cases       []CaseRef
 }
 
@@ -217,7 +219,7 @@ func Discover(packsDir, pattern string, names ...string) ([]PlanRef, error) {
 		}
 		plans = append(plans, PlanRef{
 			Name: name, PackVersion: packVersion, Path: path, Services: plan.Services,
-			Versions: plan.Versions, Runner: plan.Runner, Shards: plan.Shards, Cases: cases,
+			Versions: plan.Versions, Runner: plan.Runner, Shards: plan.Shards, Workers: plan.Workers, Cases: cases,
 		})
 	}
 	if len(plans) == 0 {
@@ -332,6 +334,22 @@ func loadPackVersion(packDir string) (string, error) {
 		return "", fmt.Errorf("pack.yaml has no version")
 	}
 	return manifest.Version, nil
+}
+
+// packTestMaxWorkers caps how many cases run at once. A plan may ask for fewer
+// when one SUT is heavy enough that four of them starve each other.
+const packTestMaxWorkers = 4
+
+// Workers reports how many of a selection's cases may run at once, which is the
+// smallest any selected plan is willing to tolerate.
+func Workers(plans []PlanRef) int {
+	workers := packTestMaxWorkers
+	for _, plan := range plans {
+		if plan.Workers > 0 && plan.Workers < workers {
+			workers = plan.Workers
+		}
+	}
+	return workers
 }
 
 func Matrix(plans []PlanRef) []MatrixRow {
@@ -537,6 +555,9 @@ func validatePlan(pack string, plan Plan, actions map[string]actionDefinition) e
 	}
 	if plan.Shards < 0 || plan.Shards > len(plan.Cases) {
 		return fmt.Errorf("shards must be between 1 and the %d declared cases", len(plan.Cases))
+	}
+	if plan.Workers < 0 || plan.Workers > packTestMaxWorkers {
+		return fmt.Errorf("workers must be between 1 and %d", packTestMaxWorkers)
 	}
 	seen := make(map[string]bool, len(plan.Cases))
 	successfulActions := make(map[string]bool, len(plan.Cases))

--- a/tools/internal/packtest/packtest_test.go
+++ b/tools/internal/packtest/packtest_test.go
@@ -590,3 +590,16 @@ func TestMatrixEmptyMarshalsAsArrayNotNull(t *testing.T) {
 		}
 	}
 }
+
+func TestWorkersTakesTheSmallestPlanCap(t *testing.T) {
+	if got := Workers([]PlanRef{{Name: "redis"}}); got != 4 {
+		t.Fatalf("undeclared plans run at the cap, got %d", got)
+	}
+	plans := []PlanRef{{Name: "redis"}, {Name: "kubernetes", Workers: 2}}
+	if got := Workers(plans); got != 2 {
+		t.Fatalf("a selection runs at its most restrictive plan, got %d", got)
+	}
+	if got := Workers([]PlanRef{{Name: "k", Workers: 9}}); got != 4 {
+		t.Fatalf("a plan cannot raise the cap, got %d", got)
+	}
+}


### PR DESCRIPTION
Three fixtures shipped broken in the pack-behavior speed work because a green
local run read as a verdict — rabbitmq raced its entrypoint, zookeeper proved
loopback instead of the bridge, haproxy hit a buildx builder that only exists in
CI. None could fail locally. The fixes trailed as separate commits, so `main`
carries two commits that would fail CI if checked out.

Knowing the limitation was never the gap; the pack fixture rule already said a
workstation cannot judge that class. The gap is that a long local run ends in a
pass count, and a pass count reads as an answer.

- `./run test packs` now ends a passing run by naming what this host could not
  decide — uid ownership, AppArmor, startup races — and pointing at the matrix.
  It reports rather than fails: iterating locally is the point.
- The Definition of Done names the three surfaces where the local gate is a
  false pass: `packs/*/test/`, `.github/workflows/`, `dev/test-packs/`.
- The rule card carries the shape, the surface table, and a sweep signal — a
  task in `99_done/` touching those surfaces with no CI run read for it, and a
  fix commit that repairs the commit immediately before it.

`packTestHostBlindSpots` is unit-tested against a workstation, Docker Desktop on
Linux, a roomy Linux host, and a runner-shaped host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)