### PR TITLE
Pull a plan's images before its cases race them

### DIFF
--- a/packs/zookeeper/test/cases.yaml
+++ b/packs/zookeeper/test/cases.yaml
@@ -1,4 +1,8 @@
 services: [zookeeper]
+
+# Four JVMs starting at once starve the NIO thread that answers four-letter
+# words, and a starved one closes the connection without a reply.
+workers: 2
 versions:
   - version: "7.9.8"
     digest: "@sha256:48ca7843cdf2e9d35f96b86efd290e81fcedd595cd5d7df8fde3a6724c3c5869"

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -443,6 +443,13 @@ func (a *App) preparePackTestPlan(
 		}
 	}
 
+	// Pull once, here, rather than letting the first wave of cases race a pull
+	// while their SUTs start. That wave was taking three times as long as the
+	// rest and starving servers that boot on a timer.
+	if err := a.run(ctx, a.Root, env, "docker", append(append([]string{}, compose...), "pull", "--quiet", "--policy", "missing")...); err != nil {
+		return "", fmt.Errorf("pull pack images: %w", err)
+	}
+
 	// Only the project name and the runner identity vary between a plan's
 	// cases, and neither reaches image resolution, so resolving here spares
 	// every case a second full parse of both Compose files.

--- a/tools/internal/devtool/pack.go
+++ b/tools/internal/devtool/pack.go
@@ -446,7 +446,10 @@ func (a *App) preparePackTestPlan(
 	// Pull once, here, rather than letting the first wave of cases race a pull
 	// while their SUTs start. That wave was taking three times as long as the
 	// rest and starving servers that boot on a timer.
-	if err := a.run(ctx, a.Root, env, "docker", append(append([]string{}, compose...), "pull", "--quiet", "--policy", "missing")...); err != nil {
+	// --ignore-buildable: a pack that ships its own client or SUT image builds
+	// it, and asking a registry for it fails.
+	if err := a.run(ctx, a.Root, env, "docker", append(append([]string{}, compose...),
+		"pull", "--quiet", "--policy", "missing", "--ignore-buildable")...); err != nil {
 		return "", fmt.Errorf("pull pack images: %w", err)
 	}
 


### PR DESCRIPTION
zookeeper lost a four-letter word on main after the merge. The failures cluster
in the first four cases of a run — the wave that starts while the SUT image is
still being pulled. Those cases take ~25s against ~8s for everything after,
because four servers boot on a box busy extracting their own image, and a
starved NIO thread closes a connection without replying.

- Pull once per plan, before any case starts. Every pack gains it; locally
  zookeeper's first four cases drop from that shape to 7s each, matching the
  rest of the run.
- zookeeper caps its cases at two at a time, the same reason kubernetes does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)