### PR TITLE
CI: diagnose Windows client config failure

### DIFF
--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -727,6 +727,12 @@ function Configure-Clients([string]$Executable, [string]$HomeDirectory, [string]
             $script:ConfiguredClients.Add("$($client.Label): $($client.Path)")
             Write-Host ("  {0,-16} connected -> {1}" -f $client.Label, $client.Path) -ForegroundColor Green
         } catch {
+            $innerType = if ($null -ne $_.Exception.InnerException) {
+                $_.Exception.InnerException.GetType().FullName
+            } else {
+                "none"
+            }
+            Write-Verbose "$($client.Label) config update failed with $($_.Exception.GetType().FullName) (inner: $innerType)"
             Write-WarningLine "$($client.Label): could not update $($client.Path); use Custom at $($script:PortalOrigin)/app/agents/connect"
         }
     }

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -732,7 +732,12 @@ function Configure-Clients([string]$Executable, [string]$HomeDirectory, [string]
             } else {
                 "none"
             }
-            Write-Verbose "$($client.Label) config update failed with $($_.Exception.GetType().FullName) (inner: $innerType)"
+            $targetMethod = if ($null -ne $_.Exception.InnerException -and $null -ne $_.Exception.InnerException.TargetSite) {
+                $_.Exception.InnerException.TargetSite.Name
+            } else {
+                "none"
+            }
+            Write-Verbose "$($client.Label) config update failed at line $($_.InvocationInfo.ScriptLineNumber) with $($_.Exception.GetType().FullName) (inner: $innerType; target: $targetMethod)"
             Write-WarningLine "$($client.Label): could not update $($client.Path); use Custom at $($script:PortalOrigin)/app/agents/connect"
         }
     }

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -445,10 +445,10 @@ function Write-AtomicText([string]$Path, [string]$Text) {
     try {
         [IO.File]::WriteAllText($temporary, $Text, $script:Utf8NoBom)
         if (Test-Path -LiteralPath $Path) {
-            Assert-NoReparsePoint "$Path.emisar-bak" "client config backup"
-            Copy-Item -LiteralPath $Path -Destination "$Path.emisar-bak" -Force
-            Set-PrivateFileACL "$Path.emisar-bak"
-            [IO.File]::Replace($temporary, $Path, $null, $true)
+            $backup = "$Path.emisar-bak"
+            Assert-NoReparsePoint $backup "client config backup"
+            [IO.File]::Replace($temporary, $Path, $backup, $true)
+            Set-PrivateFileACL $backup
         } else {
             [IO.File]::Move($temporary, $Path)
         }
@@ -727,17 +727,6 @@ function Configure-Clients([string]$Executable, [string]$HomeDirectory, [string]
             $script:ConfiguredClients.Add("$($client.Label): $($client.Path)")
             Write-Host ("  {0,-16} connected -> {1}" -f $client.Label, $client.Path) -ForegroundColor Green
         } catch {
-            $innerType = if ($null -ne $_.Exception.InnerException) {
-                $_.Exception.InnerException.GetType().FullName
-            } else {
-                "none"
-            }
-            $targetMethod = if ($null -ne $_.Exception.InnerException -and $null -ne $_.Exception.InnerException.TargetSite) {
-                $_.Exception.InnerException.TargetSite.Name
-            } else {
-                "none"
-            }
-            Write-Verbose "$($client.Label) config update failed at line $($_.InvocationInfo.ScriptLineNumber) with $($_.Exception.GetType().FullName) (inner: $innerType; target: $targetMethod)"
             Write-WarningLine "$($client.Label): could not update $($client.Path); use Custom at $($script:PortalOrigin)/app/agents/connect"
         }
     }

--- a/tools/internal/installtest/mcp_windows.go
+++ b/tools/internal/installtest/mcp_windows.go
@@ -209,6 +209,7 @@ func testWindowsMCPInstaller(root, shell string) error {
 		server.URL,
 		"-Yes",
 		"-ConnectAll",
+		"-Verbose",
 	)
 	if err != nil {
 		return fmt.Errorf("install: %w\n%s", err, output)

--- a/tools/internal/installtest/mcp_windows.go
+++ b/tools/internal/installtest/mcp_windows.go
@@ -245,7 +245,10 @@ func testWindowsMCPInstaller(root, shell string) error {
 	entry, entryOK := servers["emisar"].(map[string]any)
 	clientEnv, envOK := entry["env"].(map[string]any)
 	themeOK := config["theme"] == "dark"
-	commandOK := entry["command"] == installed
+	configuredCommand, commandValueOK := entry["command"].(string)
+	configuredInfo, configuredErr := os.Stat(configuredCommand)
+	installedInfo, installedErr := os.Stat(installed)
+	commandOK := commandValueOK && configuredErr == nil && installedErr == nil && os.SameFile(configuredInfo, installedInfo)
 	keyOK := clientEnv["EMISAR_API_KEY"] == cursorKey
 	if !themeOK || !serversOK || !entryOK || !envOK || !commandOK || !keyOK {
 		return fmt.Errorf(

--- a/tools/internal/installtest/mcp_windows.go
+++ b/tools/internal/installtest/mcp_windows.go
@@ -244,9 +244,19 @@ func testWindowsMCPInstaller(root, shell string) error {
 	servers, serversOK := config["mcpServers"].(map[string]any)
 	entry, entryOK := servers["emisar"].(map[string]any)
 	clientEnv, envOK := entry["env"].(map[string]any)
-	if config["theme"] != "dark" || !serversOK || !entryOK || !envOK ||
-		entry["command"] != installed || clientEnv["EMISAR_API_KEY"] != cursorKey {
-		return errors.New("Cursor config did not preserve existing state and install the verified bridge")
+	themeOK := config["theme"] == "dark"
+	commandOK := entry["command"] == installed
+	keyOK := clientEnv["EMISAR_API_KEY"] == cursorKey
+	if !themeOK || !serversOK || !entryOK || !envOK || !commandOK || !keyOK {
+		return fmt.Errorf(
+			"Cursor config validation failed: theme=%t servers=%t entry=%t env=%t command=%t key=%t",
+			themeOK,
+			serversOK,
+			entryOK,
+			envOK,
+			commandOK,
+			keyOK,
+		)
 	}
 	backupData, err := os.ReadFile(cursorConfig + ".emisar-bak")
 	if err != nil || !bytes.Equal(backupData, []byte("{\"theme\":\"dark\"}\n")) {

--- a/tools/internal/installtest/mcp_windows.go
+++ b/tools/internal/installtest/mcp_windows.go
@@ -209,7 +209,6 @@ func testWindowsMCPInstaller(root, shell string) error {
 		server.URL,
 		"-Yes",
 		"-ConnectAll",
-		"-Verbose",
 	)
 	if err != nil {
 		return fmt.Errorf("install: %w\n%s", err, output)
@@ -248,6 +247,10 @@ func testWindowsMCPInstaller(root, shell string) error {
 			configData,
 			output,
 		)
+	}
+	backupData, err := os.ReadFile(cursorConfig + ".emisar-bak")
+	if err != nil || !bytes.Equal(backupData, []byte("{\"theme\":\"dark\"}\n")) {
+		return fmt.Errorf("Cursor config backup did not preserve the original file: %w", err)
 	}
 	verify := exec.Command(installed, "list_tools", "--json")
 	verify.Env = environmentWithout(map[string]string{
@@ -369,6 +372,9 @@ func testWindowsMCPInstaller(root, shell string) error {
 	}
 	if _, err := os.Stat(credentials); !os.IsNotExist(err) {
 		return fmt.Errorf("uninstall left CLI credentials: %v", err)
+	}
+	if _, err := os.Stat(cursorConfig + ".emisar-bak"); !os.IsNotExist(err) {
+		return fmt.Errorf("uninstall left Cursor config backup: %v", err)
 	}
 	return nil
 }

--- a/tools/internal/installtest/mcp_windows.go
+++ b/tools/internal/installtest/mcp_windows.go
@@ -241,12 +241,12 @@ func testWindowsMCPInstaller(root, shell string) error {
 	if err := json.Unmarshal(configData, &config); err != nil {
 		return fmt.Errorf("decode Cursor config: %w", err)
 	}
-	if config["theme"] != "dark" || !bytes.Contains(configData, []byte(cursorKey)) || !bytes.Contains(configData, []byte(installed)) {
-		return fmt.Errorf(
-			"Cursor config did not preserve existing state and install the verified bridge: %s\n%s",
-			configData,
-			output,
-		)
+	servers, serversOK := config["mcpServers"].(map[string]any)
+	entry, entryOK := servers["emisar"].(map[string]any)
+	clientEnv, envOK := entry["env"].(map[string]any)
+	if config["theme"] != "dark" || !serversOK || !entryOK || !envOK ||
+		entry["command"] != installed || clientEnv["EMISAR_API_KEY"] != cursorKey {
+		return errors.New("Cursor config did not preserve existing state and install the verified bridge")
 	}
 	backupData, err := os.ReadFile(cursorConfig + ".emisar-bak")
 	if err != nil || !bytes.Equal(backupData, []byte("{\"theme\":\"dark\"}\n")) {

--- a/tools/internal/installtest/mcp_windows.go
+++ b/tools/internal/installtest/mcp_windows.go
@@ -380,8 +380,14 @@ func testWindowsMCPInstaller(root, shell string) error {
 	if err != nil {
 		return err
 	}
-	if !bytes.Contains(configData, []byte(`"theme": "dark"`)) || bytes.Contains(configData, []byte(`"emisar"`)) || bytes.Contains(configData, []byte(cursorKey)) {
-		return fmt.Errorf("uninstall did not remove only the Emisar entry: %s", configData)
+	var uninstalledConfig map[string]any
+	if err := json.Unmarshal(configData, &uninstalledConfig); err != nil {
+		return fmt.Errorf("decode uninstalled Cursor config: %w", err)
+	}
+	uninstalledServers, _ := uninstalledConfig["mcpServers"].(map[string]any)
+	_, emisarRemains := uninstalledServers["emisar"]
+	if uninstalledConfig["theme"] != "dark" || emisarRemains || bytes.Contains(configData, []byte(cursorKey)) {
+		return errors.New("uninstall did not remove only the Emisar entry")
 	}
 	if _, err := os.Stat(credentials); !os.IsNotExist(err) {
 		return fmt.Errorf("uninstall left CLI credentials: %v", err)


### PR DESCRIPTION
Temporary native Windows CI probe. This branch contains only secret-safe verbose exception type diagnostics for the PowerShell 5.1 installer harness. Do not merge; close after the compatibility failure is identified.