### PR TITLE
Re-pin the trusted release workflows to the merged commit

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -27,4 +27,4 @@ jobs:
       checks: read
       contents: write
       id-token: write
-    uses: AndrewDryga/emisar/.github/workflows/mcp-release-trusted.yml@1a2a47c132d148cf4e837634650839d582003d1e
+    uses: AndrewDryga/emisar/.github/workflows/mcp-release-trusted.yml@63236244564c7a5bcfd7632150304c7d6e0e8e2e

--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -28,4 +28,4 @@ jobs:
       contents: write
       id-token: write
       packages: write
-    uses: AndrewDryga/emisar/.github/workflows/runner-release-trusted.yml@1a2a47c132d148cf4e837634650839d582003d1e
+    uses: AndrewDryga/emisar/.github/workflows/runner-release-trusted.yml@63236244564c7a5bcfd7632150304c7d6e0e8e2e

--- a/infra/github_oidc.tf
+++ b/infra/github_oidc.tf
@@ -10,7 +10,7 @@ locals {
   # authority (or, worse, an unreviewed commit keeps it). One definition makes
   # the rotation a single edit. See the rotation note on
   # google_iam_workload_identity_pool_provider.github_releases below.
-  trusted_job_workflow_sha = "1a2a47c132d148cf4e837634650839d582003d1e"
+  trusted_job_workflow_sha = "63236244564c7a5bcfd7632150304c7d6e0e8e2e"
 
   # Workflow identities carry the repository path, so during the transfer
   # window every path in var.github_repositories yields one accepted spelling.


### PR DESCRIPTION
PR #56 landed as a squash, so the commit the release shims and `infra/github_oidc.tf` pinned (`1a2a47c1`) is no longer on main and a release would run an unreachable trusted workflow. This pins all three sites to the merged commit `632362445`; `./run ops verify-release-pins` and `./run gate infra` are green.

Single commit, so a squash merge preserves it as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)